### PR TITLE
Bugfix/spinner opp mange noder iq1

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -20,7 +20,7 @@ spec:
     min: 2
     max: 4
   ingresses:
-    - "https://dittnav-event-aggregator.dev-sbs.nais.io"
+    - "https://dittnav-event-aggregator-q1.dev-sbs.nais.io"
   vault:
     enabled: true
   env:

--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -29,7 +29,7 @@ spec:
     - name: KAFKA_SCHEMAREGISTRY_SERVERS
       value: "https://kafka-schema-registry.nais-q.adeo.no"
     - name: GROUP_ID
-      value: "dittnav-aggregator-alpha-001"
+      value: "dittnav-aggregator-alpha-002"
     - name: DB_NAME
       value: "dittnav-event-cache-preprod"
     - name: DB_HOST
@@ -38,8 +38,8 @@ spec:
       value: "postgresql/preprod-fss"
   resources:
     limits:
-      cpu: 500m
+      cpu: "3"
       memory: 512Mi
     requests:
-      cpu: 200m
-      memory: 256Mi
+      cpu: "1"
+      memory: 512Mi

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/api/health.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/api/health.kt
@@ -32,13 +32,22 @@ fun Routing.healthApi(appContext: ApplicationContext) {
         }
     }
 
+    get("/selftest") {
+        var selftest = StringBuilder()
+                .append("Informasjonconsumer running ${appContext.infoConsumer.isRunning()}\r\n")
+                .append("Oppgaveconsumer running ${appContext.oppgaveConsumer.isRunning()}\r\n")
+                .append("Meldingconsumer running ${appContext.meldingConsumer.isRunning()}\r\n")
+                .append("Doneconsumer running ${appContext.doneConsumer.isRunning()}\r\n")
+        call.respondText ( text = selftest.toString(), contentType = ContentType.Text.Plain)
+    }
 }
 
 private fun isAllConsumersRunning(appContext: ApplicationContext): Boolean {
     val allConsumersRunning =
             appContext.infoConsumer.isRunning() &&
             appContext.oppgaveConsumer.isRunning() &&
-            appContext.meldingConsumer.isRunning()
+            appContext.meldingConsumer.isRunning() &&
+            appContext.doneConsumer.isRunning()
     return allConsumersRunning
 }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/PostgresDatabase.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/PostgresDatabase.kt
@@ -57,7 +57,8 @@ class PostgresDatabase(env: Environment) : Database {
                 minimumIdle = 0
                 maxLifetime = 30001
                 maximumPoolSize = 2
-                connectionTimeout = 250
+                connectionTimeout = 500
+                validationTimeout = 250
                 idleTimeout = 10001
                 isAutoCommit = false
                 transactionIsolation = "TRANSACTION_REPEATABLE_READ"

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
@@ -57,7 +57,9 @@ class Consumer<T>(
             MESSAGES_SEEN.labels(topic).inc(records.count().toDouble())
             eventBatchProcessorService.processEvents(records)
             logDebugOutput(records)
-            kafkaConsumer.commitSync()
+            if (isEventsFound(records)) {
+                kafkaConsumer.commitSync()
+            }
 
         } catch (rde: RetriableDatabaseException) {
             log.warn("Klarte ikke å skrive til databasen, prøver igjen senrere. Topic: $topic", rde)
@@ -79,6 +81,8 @@ class Consumer<T>(
             stopPolling()
         }
     }
+
+    private fun isEventsFound(records: ConsumerRecords<String, T>) = records.count() > 0
 
     private fun logDebugOutput(records: ConsumerRecords<String, T>) {
         if (!records.isEmpty) {


### PR DESCRIPTION
Rettet opp i konfig-feil som gjorde at appen oppførte seg rart i det den ble flyttet til Q1 og Kafka-versjonen i sbs-dev ble oppgrader.

Oppsummert:
* Økt CPU-limiten, slik at appen ikke spinner opp flere instanser.
* Justert opp antallet partisjoner for appen til å være to (dette er gjort i kafka-iac-repo-et vårt).
* Lag til slik at appen kun commit-er mot Kafka i tilfeller hvor det faktisk har blitt mottatt eventer.
* Justert inkonsistente timeout-verdier mot Postgres.