### PR TITLE
Feature/uid done events

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedQueriesTest.kt
@@ -16,6 +16,10 @@ class BeskjedQueriesTest {
     private val Beskjed3: Beskjed
     private val Beskjed4: Beskjed
 
+    private val produsent = "DittNAV"
+    private val fodselsnummer = "12345"
+    private val eventId = "2"
+
     private val allEvents: List<Beskjed>
     private val allEventsForSingleUser: List<Beskjed>
 
@@ -32,7 +36,7 @@ class BeskjedQueriesTest {
         var beskjed = BeskjedObjectMother.createBeskjed(eventId, fodselsnummer)
         return runBlocking {
             database.dbQuery {
-                createBeskjed(beskjed).entityId.let{
+                createBeskjed(beskjed).entityId.let {
                     beskjed.copy(id = it)
                 }
             }
@@ -59,11 +63,11 @@ class BeskjedQueriesTest {
     @Test
     fun `Finner alle aktive cachede Beskjed-eventer`() {
         runBlocking {
-            database.dbQuery { setBeskjedAktivFlag("2", false) }
+            database.dbQuery { setBeskjedAktivFlag(eventId, produsent, fodselsnummer, false) }
             val result = database.dbQuery { getAllBeskjedByAktiv(true) }
             result `should contain all` listOf(Beskjed1, Beskjed3, Beskjed4)
             result `should not contain` Beskjed2
-            database.dbQuery { setBeskjedAktivFlag("2", true) }
+            database.dbQuery { setBeskjedAktivFlag(eventId, produsent, fodselsnummer, true) }
         }
     }
 
@@ -87,7 +91,7 @@ class BeskjedQueriesTest {
     @Test
     fun `Finner cachede Beskjeds-eventer for fodselsnummer`() {
         runBlocking {
-            val result = database.dbQuery { getBeskjedByFodselsnummer("12345") }
+            val result = database.dbQuery { getBeskjedByFodselsnummer(fodselsnummer) }
             result.size `should be equal to` 3
             result `should contain all` allEventsForSingleUser
         }
@@ -104,7 +108,7 @@ class BeskjedQueriesTest {
     @Test
     fun `Finner cachet Beskjed-event med eventId`() {
         runBlocking {
-            val result = database.dbQuery { getBeskjedByEventId("2") }
+            val result = database.dbQuery { getBeskjedByEventId(eventId) }
             result `should equal` Beskjed2
         }
     }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueriesTest.kt
@@ -23,9 +23,9 @@ class BrukernotifikasjonQueriesTest {
     private val oppgave1 = OppgaveObjectMother.createOppgave("1", "12")
     private val beskjed1 = BeskjedObjectMother.createBeskjed("2", "12")
     private val innboks1 = InnboksObjectMother.createInnboks("3", "12")
-    private val brukernotifikasjon1 = Brukernotifikasjon("1", "DittNav", EventType.OPPGAVE)
-    private val brukernotifikasjon2 = Brukernotifikasjon("2", "DittNav", EventType.BESKJED)
-    private val brukernotifikasjon3 = Brukernotifikasjon("3", "DittNav", EventType.INNBOKS)
+    private val brukernotifikasjon1 = Brukernotifikasjon("1", "DittNAV", EventType.OPPGAVE, "12")
+    private val brukernotifikasjon2 = Brukernotifikasjon("2", "DittNAV", EventType.BESKJED, "12")
+    private val brukernotifikasjon3 = Brukernotifikasjon("3", "DittNAV", EventType.INNBOKS, "12")
     private val allBrukernotifikasjonEvents = listOf(brukernotifikasjon1, brukernotifikasjon2, brukernotifikasjon3)
 
     init {

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksQueriesTest.kt
@@ -20,6 +20,9 @@ class InnboksQueriesTest {
     private val innboks2: Innboks
     private val innboks3: Innboks
 
+    private val produsent = "DittNAV"
+    private val eventId = "1"
+
     private val allInnboks: List<Innboks>
     private val allInnboksForAktor1: List<Innboks>
 
@@ -78,12 +81,12 @@ class InnboksQueriesTest {
     fun `setter aktiv flag`() {
         runBlocking {
             database.dbQuery {
-                setInnboksAktivFlag("1", false)
-                var innboks = getInnboksByEventId("1")
+                setInnboksAktivFlag(eventId, produsent, fodselsnummer1, false)
+                var innboks = getInnboksByEventId(eventId)
                 innboks.aktiv `should be equal to` false
 
-                setInnboksAktivFlag("1", true)
-                innboks = getInnboksByEventId("1")
+                setInnboksAktivFlag(eventId, produsent, fodselsnummer1, true)
+                innboks = getInnboksByEventId(eventId)
                 innboks.aktiv `should be equal to` true
             }
         }
@@ -93,7 +96,7 @@ class InnboksQueriesTest {
     fun `finner Innboks etter aktiv flag`() {
         runBlocking {
             database.dbQuery {
-                setInnboksAktivFlag(innboks1.eventId, false)
+                setInnboksAktivFlag(innboks1.eventId, produsent, fodselsnummer1, false)
                 val aktiveInnboks = getAllInnboksByAktiv(true)
                 val inaktivInnboks = getAllInnboksByAktiv(false)
 
@@ -102,7 +105,7 @@ class InnboksQueriesTest {
                 inaktivInnboks.single { it.id == innboks1.id }
                 inaktivInnboks.size `should be equal to` 1
 
-                setInnboksAktivFlag(innboks1.eventId, true)
+                setInnboksAktivFlag(innboks1.eventId, produsent, fodselsnummer1, true)
             }
         }
     }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveQueriesTest.kt
@@ -18,6 +18,9 @@ class OppgaveQueriesTest {
     private val oppgave2: Oppgave
     private val oppgave3: Oppgave
 
+    private val produsent = "DittNAV"
+    private val eventId = "2"
+
     private val allEvents: List<Oppgave>
     private val allEventsForSingleUser: List<Oppgave>
 
@@ -59,11 +62,11 @@ class OppgaveQueriesTest {
     @Test
     fun `Finner alle aktive cachede Oppgave-eventer`() {
         runBlocking {
-            database.dbQuery { setOppgaveAktivFlag("2", false) }
+            database.dbQuery { setOppgaveAktivFlag(eventId, produsent, fodselsnummer2, false) }
             val result = database.dbQuery { getAllOppgaveByAktiv(true) }
             result `should contain all` listOf(oppgave1, oppgave3)
             result `should not contain` oppgave2
-            database.dbQuery { setOppgaveAktivFlag("2", true) }
+            database.dbQuery { setOppgaveAktivFlag(eventId, produsent, fodselsnummer2,  true) }
         }
     }
 
@@ -104,7 +107,7 @@ class OppgaveQueriesTest {
     @Test
     fun `Finner cachet Oppgave-event med eventId`() {
         runBlocking {
-            val result = database.dbQuery { getOppgaveByEventId("2") }
+            val result = database.dbQuery { getOppgaveByEventId(eventId) }
             result `should equal` oppgave2
         }
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.beskjed
 import java.time.LocalDateTime
 
 data class Beskjed(
+        val uid: String,
         val id: Int?,
         val produsent: String,
         val eventId: String,
@@ -16,7 +17,8 @@ data class Beskjed(
         val synligFremTil: LocalDateTime?,
         val aktiv: Boolean
 ) {
-    constructor(produsent: String,
+    constructor(uid: String,
+                produsent: String,
                 eventId: String,
                 eventTidspunkt: LocalDateTime,
                 fodselsnummer: String,
@@ -27,7 +29,8 @@ data class Beskjed(
                 sistOppdatert: LocalDateTime,
                 synligFremTil: LocalDateTime?,
                 aktiv: Boolean
-    ) : this(null,
+    ) : this(uid,
+            null,
             produsent,
             eventId,
             eventTidspunkt,

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformer.kt
@@ -4,12 +4,15 @@ import no.nav.brukernotifikasjon.schemas.Nokkel
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.util.UUID
 
 object BeskjedTransformer {
 
     fun toInternal(externalNokkel: Nokkel, externalValue: no.nav.brukernotifikasjon.schemas.Beskjed): Beskjed {
         val newRecordsAreActiveByDefault = true
-        val internal = Beskjed(externalNokkel.getSystembruker(),
+        val internal = Beskjed(
+                createRandomStringUUID(),
+                externalNokkel.getSystembruker(),
                 externalNokkel.getEventId(),
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(externalValue.getTidspunkt()), ZoneId.of("Europe/Oslo")),
                 externalValue.getFodselsnummer(),
@@ -26,5 +29,10 @@ object BeskjedTransformer {
 
     private fun no.nav.brukernotifikasjon.schemas.Beskjed.getAsTimeZoneOslo(): LocalDateTime? {
         return getSynligFremTil()?.let { datetime -> LocalDateTime.ofInstant(Instant.ofEpochMilli(datetime), ZoneId.of("Europe/Oslo")) }
+    }
+
+    private fun createRandomStringUUID(): String {
+        return UUID.randomUUID().toString()
+
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
@@ -82,7 +82,7 @@ fun Connection.getBeskjedByEventId(eventId: String): Beskjed =
 
 private fun ResultSet.toBeskjed(): Beskjed {
     return Beskjed(
-            uid = getString("uid"),
+            uid = getNullableUid("uid"),
             id = getInt("id"),
             produsent = getString("produsent"),
             eventTidspunkt = LocalDateTime.ofInstant(getTimestamp("eventTidspunkt").toInstant(), ZoneId.of("Europe/Oslo")),
@@ -100,4 +100,12 @@ private fun ResultSet.toBeskjed(): Beskjed {
 
 private fun ResultSet.getNullableLocalDateTime(label: String): LocalDateTime? {
     return getTimestamp(label)?.let { timestamp -> LocalDateTime.ofInstant(timestamp.toInstant(), ZoneId.of("Europe/Oslo")) }
+}
+
+private fun ResultSet.getNullableUid(label: String): String {
+    if (getString(label).isNullOrBlank()) {
+        return "0"
+    } else {
+        return getString(label)
+    }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
@@ -82,7 +82,7 @@ fun Connection.getBeskjedByEventId(eventId: String): Beskjed =
 
 private fun ResultSet.toBeskjed(): Beskjed {
     return Beskjed(
-            uid = getNullableUid("uid"),
+            uid = getString("uid"),
             id = getInt("id"),
             produsent = getString("produsent"),
             eventTidspunkt = LocalDateTime.ofInstant(getTimestamp("eventTidspunkt").toInstant(), ZoneId.of("Europe/Oslo")),
@@ -97,15 +97,7 @@ private fun ResultSet.toBeskjed(): Beskjed {
             aktiv = getBoolean("aktiv")
     )
 }
-
 private fun ResultSet.getNullableLocalDateTime(label: String): LocalDateTime? {
     return getTimestamp(label)?.let { timestamp -> LocalDateTime.ofInstant(timestamp.toInstant(), ZoneId.of("Europe/Oslo")) }
 }
 
-private fun ResultSet.getNullableUid(label: String): String {
-    if (getString(label).isNullOrBlank()) {
-        return "0"
-    } else {
-        return getString(label)
-    }
-}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
@@ -19,19 +19,20 @@ fun Connection.getAllBeskjed(): List<Beskjed> =
                 }
 
 fun Connection.createBeskjed(beskjed: Beskjed): PersistActionResult =
-        executePersistQuery("""INSERT INTO BESKJED (produsent, eventTidspunkt, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, synligFremTil, aktiv)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""") {
-            setString(1, beskjed.produsent)
-            setObject(2, beskjed.eventTidspunkt, Types.TIMESTAMP)
-            setString(3, beskjed.fodselsnummer)
-            setString(4, beskjed.eventId)
-            setString(5, beskjed.grupperingsId)
-            setString(6, beskjed.tekst)
-            setString(7, beskjed.link)
-            setInt(8, beskjed.sikkerhetsnivaa)
-            setObject(9, beskjed.sistOppdatert, Types.TIMESTAMP)
-            setObject(10, beskjed.synligFremTil, Types.TIMESTAMP)
-            setBoolean(11, beskjed.aktiv)
+        executePersistQuery("""INSERT INTO BESKJED (uid, produsent, eventTidspunkt, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, synligFremTil, aktiv)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""") {
+            setString(1, beskjed.uid)
+            setString(2, beskjed.produsent)
+            setObject(3, beskjed.eventTidspunkt, Types.TIMESTAMP)
+            setString(4, beskjed.fodselsnummer)
+            setString(5, beskjed.eventId)
+            setString(6, beskjed.grupperingsId)
+            setString(7, beskjed.tekst)
+            setString(8, beskjed.link)
+            setInt(9, beskjed.sikkerhetsnivaa)
+            setObject(10, beskjed.sistOppdatert, Types.TIMESTAMP)
+            setObject(11, beskjed.synligFremTil, Types.TIMESTAMP)
+            setBoolean(12, beskjed.aktiv)
         }
 
 fun Connection.setBeskjedAktivFlag(eventId: String, aktiv: Boolean): Int =
@@ -79,6 +80,7 @@ fun Connection.getBeskjedByEventId(eventId: String): Beskjed =
 
 private fun ResultSet.toBeskjed(): Beskjed {
     return Beskjed(
+            uid = getString("uid"),
             id = getInt("id"),
             produsent = getString("produsent"),
             eventTidspunkt = LocalDateTime.ofInstant(getTimestamp("eventTidspunkt").toInstant(), ZoneId.of("Europe/Oslo")),

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
@@ -35,17 +35,19 @@ fun Connection.createBeskjed(beskjed: Beskjed): PersistActionResult =
             setBoolean(12, beskjed.aktiv)
         }
 
-fun Connection.setBeskjedAktivFlag(eventId: String, aktiv: Boolean): Int =
-        prepareStatement("""UPDATE BESKJED SET aktiv = ? WHERE eventId = ?""").use {
+fun Connection.setBeskjedAktivFlag(eventId: String, produsent: String, fodselsnummer: String, aktiv: Boolean): Int =
+        prepareStatement("""UPDATE BESKJED SET aktiv = ? WHERE eventId = ? AND produsent = ? AND fodselsnummer = ?""").use {
             it.setBoolean(1, aktiv)
             it.setString(2, eventId)
+            it.setString(3, produsent)
+            it.setString(4, fodselsnummer)
             it.executeUpdate()
         }
 
 fun Connection.getAllBeskjedByAktiv(aktiv: Boolean): List<Beskjed> =
         prepareStatement("""SELECT * FROM BESKJED WHERE aktiv = ?""")
                 .use {
-                    it.setBoolean(1,aktiv)
+                    it.setBoolean(1, aktiv)
                     it.executeQuery().list {
                         toBeskjed()
                     }
@@ -96,6 +98,6 @@ private fun ResultSet.toBeskjed(): Beskjed {
     )
 }
 
-private fun ResultSet.getNullableLocalDateTime(label: String) : LocalDateTime? {
+private fun ResultSet.getNullableLocalDateTime(label: String): LocalDateTime? {
     return getTimestamp(label)?.let { timestamp -> LocalDateTime.ofInstant(timestamp.toInstant(), ZoneId.of("Europe/Oslo")) }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/Brukernotifikasjon.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/Brukernotifikasjon.kt
@@ -3,7 +3,8 @@ package no.nav.personbruker.dittnav.eventaggregator.common.database.entity
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 
 data class Brukernotifikasjon(
-    val id: String,
-    val produsent: String,
-    val type: EventType
+        val eventId: String,
+        val produsent: String,
+        val type: EventType,
+        val fodselsnummer: String
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueries.kt
@@ -15,8 +15,9 @@ fun Connection.getAllBrukernotifikasjonFromView(): List<Brukernotifikasjon> =
 
 private fun ResultSet.toBrukernotifikasjon(): Brukernotifikasjon {
     return Brukernotifikasjon(
-            id = getString("eventId"),
+            eventId = getString("eventId"),
             produsent = getString("produsent"),
-            type = EventType.valueOf(getString("type").toUpperCase())
+            type = EventType.valueOf(getString("type").toUpperCase()),
+            fodselsnummer = getString("fodselsnummer")
     )
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
@@ -5,9 +5,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.time.delay
-import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.getAllBeskjedByAktiv
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.setBeskjedAktivFlag
+import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.innboks.getAllInnboksByAktiv
 import no.nav.personbruker.dittnav.eventaggregator.innboks.setInnboksAktivFlag
 import no.nav.personbruker.dittnav.eventaggregator.oppgave.getAllOppgaveByAktiv
@@ -20,7 +20,7 @@ import kotlin.coroutines.CoroutineContext
 class CachedDoneEventConsumer(
         val database: Database,
         val job: Job = Job()
-): CoroutineScope {
+) : CoroutineScope {
 
     private val log: Logger = LoggerFactory.getLogger(CachedDoneEventConsumer::class.java)
     private val minutesToWait = Duration.ofMinutes(5)
@@ -49,14 +49,14 @@ class CachedDoneEventConsumer(
         val allAktivOppgave = database.dbQuery { getAllOppgaveByAktiv(true) }
         val allAktivInnboks = database.dbQuery { getAllInnboksByAktiv(true) }
         allDone.forEach { done ->
-            if(allAktivBeskjed.any { it.eventId == done.eventId}) {
-                database.dbQuery { setBeskjedAktivFlag(done.eventId, false) }
+            if (allAktivBeskjed.any { beskjed -> beskjed.eventId == done.eventId && beskjed.produsent == done.produsent && beskjed.fodselsnummer == done.fodselsnummer }) {
+                database.dbQuery { setBeskjedAktivFlag(done.eventId, done.produsent, done.fodselsnummer, false) }
                 log.info("Fant nytt Beskjed-event etter tidligere mottatt Done-event, setter event med eventId ${done.eventId} inaktivt")
-            } else if(allAktivOppgave.any {it.eventId == done.eventId}) {
-                database.dbQuery { setOppgaveAktivFlag(done.eventId, false) }
+            } else if (allAktivOppgave.any { oppgave -> oppgave.eventId == done.eventId && oppgave.produsent == done.produsent && oppgave.fodselsnummer == done.fodselsnummer }) {
+                database.dbQuery { setOppgaveAktivFlag(done.eventId, done.produsent, done.fodselsnummer, false) }
                 log.info("Fant nytt Oppgave-event etter tidligere mottatt Done-event, setter event med eventId ${done.eventId} inaktivt")
-            } else if(allAktivInnboks.any {it.eventId == done.eventId}) {
-                database.dbQuery { setInnboksAktivFlag(done.eventId, false) }
+            } else if (allAktivInnboks.any { innboks -> innboks.eventId == done.eventId && innboks.produsent == done.produsent && innboks.fodselsnummer == done.fodselsnummer }) {
+                database.dbQuery { setInnboksAktivFlag(done.eventId, done.produsent, done.fodselsnummer, false) }
                 log.info("Fant nytt Innboks-event etter tidligere mottatt Done-event, setter event med eventId ${done.eventId} inaktivt")
             }
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
@@ -36,20 +36,22 @@ class DoneEventService(
     }
 
     private suspend fun processDoneEvent(event: ConsumerRecord<Nokkel, Done>) {
-        val entity = DoneTransformer.toInternal(event.getNonNullKey(), event.value())
+        val doneEntity = DoneTransformer.toInternal(event.getNonNullKey(), event.value())
         val brukernotifikasjoner = database.dbQuery { getAllBrukernotifikasjonFromView() }
-        val foundEvent: Brukernotifikasjon? = brukernotifikasjoner.find { findEventInCache(it, entity) }
+        val foundEvent: Brukernotifikasjon? = brukernotifikasjoner.find { isEventInCache(it, doneEntity) }
         if (foundEvent != null) {
             log.info("Fant matchende event for Done-event med eventId: ${foundEvent.eventId}, produsent: ${foundEvent.produsent}, type: ${foundEvent.type}")
             flagEventAsInactive(foundEvent)
         } else {
-            database.dbQuery { createDoneEvent(entity) }
-            log.info("Fant ikke matchende event for done-event med id ${entity.eventId}, produsent: ${entity.produsent}, eventTidspunkt: ${entity.eventTidspunkt}. Skrev done-event til cache")
+            database.dbQuery { createDoneEvent(doneEntity) }
+            log.info("Fant ikke matchende event for done-event med eventId ${doneEntity.eventId}, produsent: ${doneEntity.produsent}, eventTidspunkt: ${doneEntity.eventTidspunkt}. Skrev done-event til cache")
         }
     }
 
-    private fun findEventInCache(brukernotifikasjon: Brukernotifikasjon, done: no.nav.personbruker.dittnav.eventaggregator.done.Done): Boolean {
-        return (brukernotifikasjon.eventId == done.eventId && brukernotifikasjon.produsent == done.produsent && brukernotifikasjon.fodselsnummer == done.fodselsnummer)
+    private fun isEventInCache(brukernotifikasjon: Brukernotifikasjon, done: no.nav.personbruker.dittnav.eventaggregator.done.Done): Boolean {
+        return (brukernotifikasjon.eventId == done.eventId &&
+                brukernotifikasjon.produsent == done.produsent &&
+                brukernotifikasjon.fodselsnummer == done.fodselsnummer)
     }
 
     private suspend fun flagEventAsInactive(event: Brukernotifikasjon) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
@@ -41,7 +41,7 @@ class DoneEventService(
         val foundEvent: Brukernotifikasjon? = brukernotifikasjoner.find { isEventInCache(it, doneEntity) }
         if (foundEvent != null) {
             log.info("Fant matchende event for Done-event med eventId: ${foundEvent.eventId}, produsent: ${foundEvent.produsent}, type: ${foundEvent.type}")
-            flagEventAsInactive(foundEvent)
+            flagEventAsInactive(foundEvent, doneEntity)
         } else {
             database.dbQuery { createDoneEvent(doneEntity) }
             log.info("Fant ikke matchende event for done-event med eventId ${doneEntity.eventId}, produsent: ${doneEntity.produsent}, eventTidspunkt: ${doneEntity.eventTidspunkt}. Skrev done-event til cache")
@@ -54,18 +54,18 @@ class DoneEventService(
                 brukernotifikasjon.fodselsnummer == done.fodselsnummer)
     }
 
-    private suspend fun flagEventAsInactive(event: Brukernotifikasjon) {
+    suspend fun flagEventAsInactive(event: Brukernotifikasjon, done: no.nav.personbruker.dittnav.eventaggregator.done.Done) {
         when (event.type) {
             EventType.OPPGAVE -> {
-                database.dbQuery { setOppgaveAktivFlag(event.eventId, false) }
+                database.dbQuery { setOppgaveAktivFlag(done.eventId, done.produsent, done.fodselsnummer, false) }
                 log.info("Satte Oppgave-event med eventId ${event.eventId} inaktivt")
             }
             EventType.BESKJED -> {
-                database.dbQuery { setBeskjedAktivFlag(event.eventId, false) }
+                database.dbQuery { setBeskjedAktivFlag(done.eventId, done.produsent, done.fodselsnummer, false) }
                 log.info("Satte Beskjed-event med eventId ${event.eventId} inaktivt")
             }
             EventType.INNBOKS -> {
-                database.dbQuery { setInnboksAktivFlag(event.eventId, false) }
+                database.dbQuery { setInnboksAktivFlag(done.eventId, done.produsent, done.fodselsnummer, false) }
                 log.info("Satte Innboks-event med eventId ${event.eventId} inaktivt")
             }
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/innboksQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/innboksQueries.kt
@@ -6,7 +6,6 @@ import no.nav.personbruker.dittnav.eventaggregator.common.database.util.list
 import no.nav.personbruker.dittnav.eventaggregator.common.database.util.singleResult
 import java.sql.Connection
 import java.sql.ResultSet
-import java.sql.Statement
 import java.sql.Types
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -43,13 +42,15 @@ fun Connection.createInnboks(innboks: Innboks): PersistActionResult =
             setBoolean(10, innboks.aktiv)
         }
 
-fun Connection.setInnboksAktivFlag(eventId: String, aktiv: Boolean): Int =
-        prepareStatement("""UPDATE INNBOKS SET aktiv = ? WHERE eventid = ?""")
-            .use {
-                it.setBoolean(1, aktiv)
-                it.setString(2, eventId)
-                it.executeUpdate()
-            }
+fun Connection.setInnboksAktivFlag(eventId: String, produsent: String, fodselsnummer: String, aktiv: Boolean): Int =
+        prepareStatement("""UPDATE INNBOKS SET aktiv = ? WHERE eventId = ? AND produsent = ? AND fodselsnummer = ?""")
+                .use {
+                    it.setBoolean(1, aktiv)
+                    it.setString(2, eventId)
+                    it.setString(3, produsent)
+                    it.setString(4, fodselsnummer)
+                    it.executeUpdate()
+                }
 
 fun Connection.getAllInnboksByAktiv(aktiv: Boolean): List<Innboks> =
         prepareStatement("""SELECT * FROM INNBOKS WHERE aktiv = ?""")
@@ -60,7 +61,7 @@ fun Connection.getAllInnboksByAktiv(aktiv: Boolean): List<Innboks> =
                     }
                 }
 
-fun Connection.getInnboksByFodselsnummer(fodselsnummer: String) : List<Innboks> =
+fun Connection.getInnboksByFodselsnummer(fodselsnummer: String): List<Innboks> =
         prepareStatement("""SELECT * FROM INNBOKS WHERE fodselsnummer = ?""")
                 .use {
                     it.setString(1, fodselsnummer)
@@ -69,7 +70,7 @@ fun Connection.getInnboksByFodselsnummer(fodselsnummer: String) : List<Innboks> 
                     }
                 }
 
-fun Connection.getInnboksByEventId(eventId: String) : Innboks =
+fun Connection.getInnboksByEventId(eventId: String): Innboks =
         prepareStatement("""SELECT * FROM INNBOKS WHERE eventId = ?""")
                 .use {
                     it.setString(1, eventId)
@@ -77,7 +78,6 @@ fun Connection.getInnboksByEventId(eventId: String) : Innboks =
                         toInnboks()
                     }
                 }
-
 
 
 private fun ResultSet.toInnboks(): Innboks {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/oppgaveQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/oppgaveQueries.kt
@@ -6,7 +6,6 @@ import no.nav.personbruker.dittnav.eventaggregator.common.database.util.list
 import no.nav.personbruker.dittnav.eventaggregator.common.database.util.singleResult
 import java.sql.Connection
 import java.sql.ResultSet
-import java.sql.Statement
 import java.sql.Types
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -21,23 +20,25 @@ fun Connection.getAllOppgave(): List<Oppgave> =
 
 fun Connection.createOppgave(oppgave: Oppgave): PersistActionResult =
         executePersistQuery("""INSERT INTO OPPGAVE (produsent, eventTidspunkt, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, aktiv) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ? ,?)""")
-                {
-                    setString(1, oppgave.produsent)
-                    setObject(2, oppgave.eventTidspunkt, Types.TIMESTAMP)
-                    setString(3, oppgave.fodselsnummer)
-                    setString(4, oppgave.eventId)
-                    setString(5, oppgave.grupperingsId)
-                    setString(6, oppgave.tekst)
-                    setString(7, oppgave.link)
-                    setInt(8, oppgave.sikkerhetsinvaa)
-                    setObject(9, oppgave.sistOppdatert, Types.TIMESTAMP)
-                    setBoolean(10, oppgave.aktiv)
-                }
+        {
+            setString(1, oppgave.produsent)
+            setObject(2, oppgave.eventTidspunkt, Types.TIMESTAMP)
+            setString(3, oppgave.fodselsnummer)
+            setString(4, oppgave.eventId)
+            setString(5, oppgave.grupperingsId)
+            setString(6, oppgave.tekst)
+            setString(7, oppgave.link)
+            setInt(8, oppgave.sikkerhetsinvaa)
+            setObject(9, oppgave.sistOppdatert, Types.TIMESTAMP)
+            setBoolean(10, oppgave.aktiv)
+        }
 
-fun Connection.setOppgaveAktivFlag(eventId: String, aktiv: Boolean): Int =
-        prepareStatement("""UPDATE OPPGAVE SET aktiv = ? WHERE eventId = ?""").use {
+fun Connection.setOppgaveAktivFlag(eventId: String, produsent: String, fodselsnummer: String, aktiv: Boolean): Int =
+        prepareStatement("""UPDATE OPPGAVE SET aktiv = ? WHERE eventId = ? AND produsent = ? AND fodselsnummer = ?""").use {
             it.setBoolean(1, aktiv)
             it.setString(2, eventId)
+            it.setString(3, produsent)
+            it.setString(4, fodselsnummer)
             it.executeUpdate()
         }
 

--- a/src/main/resources/db/migration/V12__add_column_uid.sql
+++ b/src/main/resources/db/migration/V12__add_column_uid.sql
@@ -1,0 +1,1 @@
+ALTER TABLE BESKJED ADD COLUMN uid varchar(100);

--- a/src/main/resources/db/migration/V13__recreate_brukernotifikasjon_view_med_fnr.sql
+++ b/src/main/resources/db/migration/V13__recreate_brukernotifikasjon_view_med_fnr.sql
@@ -1,0 +1,8 @@
+DROP VIEW brukernotifikasjon_view;
+
+CREATE VIEW brukernotifikasjon_view AS
+SELECT eventId, produsent, 'beskjed' as type, fodselsnummer FROM BESKJED
+UNION
+SELECT eventId, produsent, 'oppgave' as type, fodselsnummer FROM OPPGAVE
+UNION
+SELECT eventId, produsent, 'innboks' as type, fodselsnummer FROM INNBOKS;

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
@@ -2,11 +2,13 @@ package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
 import java.time.LocalDateTime
 import java.time.ZoneId
+import kotlin.random.Random
 
 object BeskjedObjectMother {
 
     fun createBeskjed(eventId: String, fodselsnummer: String): Beskjed {
         return Beskjed(
+                uid = Random.nextInt(1,100).toString(),
                 produsent = "DittNav",
                 eventTidspunkt = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
                 synligFremTil = LocalDateTime.now(ZoneId.of("Europe/Oslo")),

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
@@ -9,7 +9,7 @@ object BeskjedObjectMother {
     fun createBeskjed(eventId: String, fodselsnummer: String): Beskjed {
         return Beskjed(
                 uid = Random.nextInt(1,100).toString(),
-                produsent = "DittNav",
+                produsent = "DittNAV",
                 eventTidspunkt = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
                 synligFremTil = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
                 fodselsnummer = fodselsnummer,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneObjectMother.kt
@@ -7,7 +7,7 @@ object DoneObjectMother {
 
     fun createDone(eventId: String): Done {
         return Done(
-                "DittNav",
+                "DittNAV",
                 eventId,
                 LocalDateTime.now(ZoneId.of("Europe/Oslo")),
                 "12345",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
@@ -7,7 +7,7 @@ object InnboksObjectMother {
 
     fun createInnboks(eventId: String, fodselsnummer: String): Innboks {
         return Innboks(
-                "DittNav",
+                "DittNAV",
                 eventId,
                 LocalDateTime.now(ZoneId.of("Europe/Oslo")),
                 fodselsnummer,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/nokkel/nokkelObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/nokkel/nokkelObjectMother.kt
@@ -2,4 +2,4 @@ package no.nav.personbruker.dittnav.eventaggregator.nokkel
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
 
-fun createNokkel(i: Int): Nokkel = Nokkel("DittNAV", i.toString())
+fun createNokkel(eventId: Int): Nokkel = Nokkel("DittNAV", eventId.toString())

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
@@ -7,7 +7,7 @@ object OppgaveObjectMother {
 
     fun createOppgave(eventId: String, fodselsnummer: String): Oppgave {
         return Oppgave(
-                produsent = "DittNav",
+                produsent = "DittNAV",
                 eventTidspunkt = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
                 fodselsnummer = fodselsnummer,
                 eventId = eventId,


### PR DESCRIPTION
BP-346: Når et beskjed-event kommer fra Kafka lager vi en uid som vi legger i cachen. Denne uid-en skal brukes for å matche et done-event som kommer fra frontend
For å være sikre på at vi setter rett event til done sjekker vi eventId, produsent og fnr.

Todo
- Optimalisere DB query