### PR TITLE
Lagt til oppdatert logback-konfig.

### DIFF
--- a/src/intTest/resources/logback.xml
+++ b/src/intTest/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration debug="true">
+    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
+
+    <property name="loggingPattern"
+              value="%d [%-5level] [%thread] %logger{5} %replace(- [%X{consumerId}, %X{callId}, %X{userId}] ){'- \[, , \] ',''}- %m%n"/>
+
+    <appender name="stdout_json" class="no.nav.personbruker.dittnav.eventaggregator.logging.MaskingAppender">
+        <appender name="stdout_json_masked" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        </appender>
+    </appender>
+
+    <appender name="metrics" class="io.prometheus.client.logback.InstrumentedAppender"/>
+
+    <root level="INFO">
+        <appender-ref ref="stdout_json"/>
+        <appender-ref ref="metrics"/>
+    </root>
+</configuration>

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedLoggingEvent.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedLoggingEvent.kt
@@ -1,0 +1,77 @@
+package no.nav.personbruker.dittnav.eventaggregator.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.spi.IThrowableProxy
+import ch.qos.logback.classic.spi.LoggerContextVO
+import no.nav.personbruker.dittnav.eventaggregator.logging.MaskedThrowableProxy.Companion.mask
+import org.slf4j.Marker
+
+class MaskedLoggingEvent internal constructor(private val iLoggingEvent: ILoggingEvent) : ILoggingEvent {
+    override fun getThreadName(): String? {
+        return iLoggingEvent.threadName
+    }
+
+    override fun getLevel(): Level? {
+        return iLoggingEvent.level
+    }
+
+    override fun getMessage(): String? {
+        return iLoggingEvent.message
+    }
+
+    override fun getArgumentArray(): Array<Any>? {
+        return iLoggingEvent.argumentArray
+    }
+
+    override fun getFormattedMessage(): String? {
+        return mask(iLoggingEvent.formattedMessage)
+    }
+
+    override fun getLoggerName(): String? {
+        return iLoggingEvent.loggerName
+    }
+
+    override fun getLoggerContextVO(): LoggerContextVO? {
+        return iLoggingEvent.loggerContextVO
+    }
+
+    override fun getThrowableProxy(): IThrowableProxy? {
+        return mask(iLoggingEvent.throwableProxy)
+    }
+
+    override fun getCallerData(): Array<StackTraceElement?>? {
+        return iLoggingEvent.callerData
+    }
+
+    override fun hasCallerData(): Boolean {
+        return iLoggingEvent.hasCallerData()
+    }
+
+    override fun getMarker(): Marker? {
+        return iLoggingEvent.marker
+    }
+
+    override fun getMDCPropertyMap(): Map<String?, String?>? {
+        return iLoggingEvent.mdcPropertyMap.mapValues { mask(it.value) }
+    }
+
+    override fun getMdc(): Map<String?, String?>? {
+        return iLoggingEvent.mdcPropertyMap.mapValues { mask(it.value) }
+    }
+
+    override fun getTimeStamp(): Long {
+        return iLoggingEvent.timeStamp
+    }
+
+    override fun prepareForDeferredProcessing() {
+        iLoggingEvent.prepareForDeferredProcessing()
+    }
+
+    companion object {
+        fun mask(string: String?): String? {
+            return string?.replace("(^|\\W)\\d{11}(?=$|\\W)".toRegex(), "$1***********")
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedThrowableProxy.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedThrowableProxy.kt
@@ -1,0 +1,44 @@
+package no.nav.personbruker.dittnav.eventaggregator.logging
+
+import ch.qos.logback.classic.spi.IThrowableProxy
+import ch.qos.logback.classic.spi.StackTraceElementProxy
+
+
+class MaskedThrowableProxy private constructor(private val throwableProxy: IThrowableProxy) : IThrowableProxy {
+    override fun getMessage(): String? {
+        return MaskedLoggingEvent.mask(throwableProxy.message)
+    }
+
+    override fun getClassName(): String? {
+        return throwableProxy.className
+    }
+
+    override fun getStackTraceElementProxyArray(): Array<StackTraceElementProxy?>? {
+        return throwableProxy.stackTraceElementProxyArray
+    }
+
+    override fun getCommonFrames(): Int {
+        return throwableProxy.commonFrames
+    }
+
+    override fun getCause(): IThrowableProxy? {
+        return mask(throwableProxy.cause)
+    }
+
+    override fun getSuppressed(): Array<IThrowableProxy?>? {
+        val suppressed = throwableProxy.suppressed
+        val maskedSuppressed = arrayOfNulls<IThrowableProxy>(suppressed.size)
+        for (i in suppressed.indices) {
+            maskedSuppressed[i] = mask(suppressed[i])
+        }
+        return maskedSuppressed
+    }
+
+    companion object {
+        @JvmStatic
+        fun mask(throwableProxy: IThrowableProxy?): IThrowableProxy? {
+            return if (throwableProxy == null) throwableProxy else MaskedThrowableProxy(throwableProxy)
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskingAppender.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskingAppender.kt
@@ -1,0 +1,17 @@
+package no.nav.personbruker.dittnav.eventaggregator.logging
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.Appender
+import ch.qos.logback.core.AppenderBase
+
+class MaskingAppender : AppenderBase<ILoggingEvent>() {
+    private var appender: Appender<ILoggingEvent>? = null
+
+    override fun append(iLoggingEvent: ILoggingEvent) {
+        appender?.doAppend(MaskedLoggingEvent(iLoggingEvent))
+    }
+
+    fun setAppender(appender: Appender<ILoggingEvent>?) {
+        this.appender = appender
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedLoggingEventTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedLoggingEventTest.kt
@@ -1,0 +1,45 @@
+package no.nav.personbruker.dittnav.eventaggregator.logging
+
+import org.amshove.kluent.`should contain`
+import org.amshove.kluent.`should equal`
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+
+class MaskedLoggingEventTest {
+    @Test
+    fun `sjekk at fodselsnummer blir maskert`() {
+        MaskedLoggingEvent.mask("-12345678901")!! `should contain` MASKED_FNR
+        MaskedLoggingEvent.mask("12345678901")!! `should contain` MASKED_FNR
+        MaskedLoggingEvent.mask(" 12345678901")!! `should contain` MASKED_FNR
+        MaskedLoggingEvent.mask("12345678901 ")!! `should contain` MASKED_FNR
+        MaskedLoggingEvent.mask(" 12345678901 ")!! `should contain` MASKED_FNR
+        MaskedLoggingEvent.mask("abc 12345678901 def")!! `should contain` MASKED_FNR
+        MaskedLoggingEvent.mask("callId=7b7c<12345676543>c8c32129c837808f7")!! `should contain` MASKED_FNR
+    }
+
+    @Test
+    fun `sjekk at data som ikke er fodselsnummer ikke blir blir maskert`() {
+        "".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
+        "abc".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
+        "1234".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
+        "1234567890".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
+        "123456789012".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
+        "callId=7b7c12345676543c8c32129c837808f7".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
+    }
+
+    @Test
+    fun `sjekk at maskering av null blir null`() {
+        MaskedLoggingEvent.mask(null) `should equal` null
+    }
+
+    @Test
+    fun `sjekk at maskert data formatteres riktig`() {
+        MaskedLoggingEvent.mask("12345678901-12345678901 12345678901")!! `should equal` "$MASKED_FNR-$MASKED_FNR $MASKED_FNR"
+        MaskedLoggingEvent.mask("12345678901,12345678901")!! `should equal` "$MASKED_FNR,$MASKED_FNR"
+    }
+
+    companion object {
+        private val LOGGER = LoggerFactory.getLogger(MaskedLoggingEventTest::class.java)
+        const val MASKED_FNR = "***********"
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedThrowableProxyTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedThrowableProxyTest.kt
@@ -1,0 +1,38 @@
+package no.nav.personbruker.dittnav.eventaggregator.logging
+
+import ch.qos.logback.classic.spi.ThrowableProxy
+import ch.qos.logback.classic.spi.ThrowableProxyUtil
+import no.nav.personbruker.dittnav.eventaggregator.logging.MaskedThrowableProxy.Companion.mask
+import org.amshove.kluent.`should contain`
+import org.amshove.kluent.`should not contain`
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class MaskedThrowableProxyTest {
+    @Test
+    fun `sjekk at maskering av fodselsnummer skjer ved kastet feil`() {
+        val sensitiveException = RuntimeException(
+            FNR,
+            IllegalArgumentException(
+                FNR,
+                Exception(FNR)
+            )
+        )
+        sensitiveException.addSuppressed(
+            IllegalStateException(
+                FNR,
+                IOException(FNR)
+            )
+        )
+        sensitiveException.printStackTrace()
+        val sensitiveThrowableProxy = ThrowableProxy(sensitiveException)
+        val maskedThrowableProxy = mask(sensitiveThrowableProxy)
+
+        ThrowableProxyUtil.asString(sensitiveThrowableProxy) `should contain` FNR
+        ThrowableProxyUtil.asString(maskedThrowableProxy) `should not contain` FNR
+    }
+
+    companion object {
+        private const val FNR = "12345678901"
+    }
+}


### PR DESCRIPTION
* Dette sørger for at stacktraces vises riktig i Kibana.
* Lag til logge-filter som erstatter strenger som ligner på fødselsnummer med stjerner (***).

PB-357. Logback config