### PR TITLE
Optimalisert ytelsen ved å i første omgang kun match-e done-eventer mot aktive brukernotifikasjoner

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedQueriesTest.kt
@@ -33,7 +33,7 @@ class BeskjedQueriesTest {
     }
 
     private fun createBeskjed(eventId: String, fodselsnummer: String): Beskjed {
-        var beskjed = BeskjedObjectMother.createBeskjed(eventId, fodselsnummer)
+        val beskjed = BeskjedObjectMother.giveMeBeskjed(eventId, fodselsnummer)
         return runBlocking {
             database.dbQuery {
                 createBeskjed(beskjed).entityId.let {

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTeardownQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTeardownQueriesTest.kt
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test
 
 class BeskjedTeardownQueriesTest {
 
-    val database = H2Database()
+    private val database = H2Database()
 
-    val beskjed1 = BeskjedObjectMother.createBeskjed("1", "12345")
-    val beskjed2 = BeskjedObjectMother.createBeskjed("2", "12345")
-    val beskjed3 = BeskjedObjectMother.createBeskjed("3", "12345")
+    private val beskjed1 = BeskjedObjectMother.giveMeBeskjed("1", "12345")
+    private val beskjed2 = BeskjedObjectMother.giveMeBeskjed("2", "12345")
+    private val beskjed3 = BeskjedObjectMother.giveMeBeskjed("3", "12345")
 
     @Test
     fun `Verifiser at alle rader i Beskjedstabellen slettes`() {

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueriesTest.kt
@@ -1,11 +1,11 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.database.entity
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.database.H2Database
-import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.createBeskjed
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.deleteAllBeskjed
+import no.nav.personbruker.dittnav.eventaggregator.common.database.H2Database
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.innboks.createInnboks
 import no.nav.personbruker.dittnav.eventaggregator.innboks.deleteAllInnboks
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.Test
 class BrukernotifikasjonQueriesTest {
 
     private val database = H2Database()
-    private val oppgave1 = OppgaveObjectMother.createOppgave("1", "12")
-    private val beskjed1 = BeskjedObjectMother.createBeskjed("2", "12")
-    private val innboks1 = InnboksObjectMother.createInnboks("3", "12")
+    private val oppgave1 = OppgaveObjectMother.giveMeOppgave("1", "12")
+    private val beskjed1 = BeskjedObjectMother.giveMeBeskjed("2", "12")
+    private val innboks1 = InnboksObjectMother.giveMeInnboks("3", "12")
     private val brukernotifikasjon1 = Brukernotifikasjon("1", "DittNAV", EventType.OPPGAVE, "12")
     private val brukernotifikasjon2 = Brukernotifikasjon("2", "DittNAV", EventType.BESKJED, "12")
     private val brukernotifikasjon3 = Brukernotifikasjon("3", "DittNAV", EventType.INNBOKS, "12")

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumerTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumerTest.kt
@@ -1,19 +1,10 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.createBeskjed
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.deleteAllBeskjed
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.getBeskjedByEventId
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.*
 import no.nav.personbruker.dittnav.eventaggregator.common.database.H2Database
-import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksObjectMother
-import no.nav.personbruker.dittnav.eventaggregator.innboks.createInnboks
-import no.nav.personbruker.dittnav.eventaggregator.innboks.deleteAllInnboks
-import no.nav.personbruker.dittnav.eventaggregator.innboks.getInnboksByEventId
-import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveObjectMother
-import no.nav.personbruker.dittnav.eventaggregator.oppgave.createOppgave
-import no.nav.personbruker.dittnav.eventaggregator.oppgave.deleteAllOppgave
-import no.nav.personbruker.dittnav.eventaggregator.oppgave.getOppgaveByEventId
+import no.nav.personbruker.dittnav.eventaggregator.innboks.*
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.*
 import org.amshove.kluent.*
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
@@ -22,10 +13,13 @@ class CachedDoneEventConsumerTest {
 
     private val database = H2Database()
     private val doneRepository = DoneRepository(database)
-    private val eventConsumer = CachedDoneEventConsumer(doneRepository)
+    private val beskjedRepository = BeskjedRepository(database)
+    private val innboksRepository = InnboksRepository(database)
+    private val opgpaveRepository = OppgaveRepository(database)
+    private val eventConsumer = CachedDoneEventConsumer(beskjedRepository, innboksRepository, opgpaveRepository, doneRepository)
 
-    private val beskjed1 = BeskjedObjectMother.createBeskjed("1", "12345")
-    private val oppgave1 = OppgaveObjectMother.createOppgave("2", "12345")
+    private val beskjed1 = BeskjedObjectMother.giveMeBeskjed("1", "12345")
+    private val oppgave1 = OppgaveObjectMother.giveMeOppgave("2", "12345")
     private val done1 = DoneObjectMother.createDone("3")
     private val done2 = DoneObjectMother.createDone("4")
     private val done3 = DoneObjectMother.createDone("5")
@@ -58,7 +52,7 @@ class CachedDoneEventConsumerTest {
     @Test
     fun `setter Beskjed-event inaktivt hvis Done-event med samme eventId tidligere er mottatt`() {
         runBlocking {
-            database.dbQuery { createBeskjed(BeskjedObjectMother.createBeskjed("3", "12345")) }
+            database.dbQuery { createBeskjed(BeskjedObjectMother.giveMeBeskjed("3", "12345")) }
             eventConsumer.processDoneEvents()
             val beskjed = database.dbQuery { getBeskjedByEventId("3") }
             beskjed.aktiv.shouldBeFalse()
@@ -68,7 +62,7 @@ class CachedDoneEventConsumerTest {
     @Test
     fun `setter Oppgave-event inaktivt hvis Done-event med samme eventId tidligere er mottatt`() {
         runBlocking {
-            database.dbQuery { createOppgave(OppgaveObjectMother.createOppgave("4", "12345")) }
+            database.dbQuery { createOppgave(OppgaveObjectMother.giveMeOppgave("4", "12345")) }
             eventConsumer.processDoneEvents()
             val oppgave = database.dbQuery { getOppgaveByEventId("4") }
             oppgave.aktiv.shouldBeFalse()
@@ -78,7 +72,7 @@ class CachedDoneEventConsumerTest {
     @Test
     fun `flag Innboks-event as inactive if Done-event with same eventId exists`() {
         runBlocking {
-            database.dbQuery { createInnboks(InnboksObjectMother.createInnboks("5", "12345")) }
+            database.dbQuery { createInnboks(InnboksObjectMother.giveMeInnboks("5", "12345")) }
             eventConsumer.processDoneEvents()
             val innboks = database.dbQuery { getInnboksByEventId("5") }
             innboks.aktiv.shouldBeFalse()
@@ -91,7 +85,7 @@ class CachedDoneEventConsumerTest {
         val expectedFodselsnr = "45678"
         val expectedProdusent = "dummyProdusent"
         val doneEvent = DoneObjectMother.createDone(expectedEventId, expectedProdusent, expectedFodselsnr)
-        val associatedBeskjed = BeskjedObjectMother.createBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
+        val associatedBeskjed = BeskjedObjectMother.giveMeBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
 
         runBlocking {
             database.dbQuery { createDoneEvent(doneEvent) }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
@@ -3,26 +3,17 @@ package no.nav.personbruker.dittnav.eventaggregator.done
 import kotlinx.coroutines.runBlocking
 import no.nav.brukernotifikasjon.schemas.Done
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.createBeskjed
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.deleteAllBeskjed
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.getAllBeskjed
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.*
 import no.nav.personbruker.dittnav.eventaggregator.common.database.H2Database
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.config.Kafka
 import no.nav.personbruker.dittnav.eventaggregator.done.schema.AvroDoneObjectMother
-import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksObjectMother
-import no.nav.personbruker.dittnav.eventaggregator.innboks.createInnboks
-import no.nav.personbruker.dittnav.eventaggregator.innboks.deleteAllInnboks
-import no.nav.personbruker.dittnav.eventaggregator.innboks.getAllInnboks
+import no.nav.personbruker.dittnav.eventaggregator.innboks.*
 import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.metrics.ProducerNameScrubber
 import no.nav.personbruker.dittnav.eventaggregator.metrics.StubMetricsReporter
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
-import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveObjectMother
-import no.nav.personbruker.dittnav.eventaggregator.oppgave.createOppgave
-import no.nav.personbruker.dittnav.eventaggregator.oppgave.deleteAllOppgave
-import no.nav.personbruker.dittnav.eventaggregator.oppgave.getAllOppgave
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.*
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be false`
 import org.amshove.kluent.shouldBeEmpty
@@ -33,15 +24,18 @@ import org.junit.jupiter.api.Test
 class DoneEventServiceTest {
 
     private val database = H2Database()
-    val metricsReporter = StubMetricsReporter()
-    val producerNameScrubber = ProducerNameScrubber("")
-    val metricsProbe = EventMetricsProbe(metricsReporter, producerNameScrubber)
+    private val metricsReporter = StubMetricsReporter()
+    private val producerNameScrubber = ProducerNameScrubber("")
+    private val metricsProbe = EventMetricsProbe(metricsReporter, producerNameScrubber)
     private val doneRepository = DoneRepository(database)
-    private val doneEventService = DoneEventService(doneRepository, metricsProbe)
-    private val beskjed1 = BeskjedObjectMother.createBeskjed("1", "12345")
-    private val oppgave = OppgaveObjectMother.createOppgave("2", "12345")
-    private val innboks = InnboksObjectMother.createInnboks("3", "12345")
-    private val beskjed2 = BeskjedObjectMother.createBeskjed("4", "12345")
+    private val beskjedRepository = BeskjedRepository(database)
+    private val innboksRepository = InnboksRepository(database)
+    private val oppgaveRepository = OppgaveRepository(database)
+    private val doneEventService = DoneEventService(doneRepository, beskjedRepository, innboksRepository, oppgaveRepository, metricsProbe)
+    private val beskjed1 = BeskjedObjectMother.giveMeBeskjed("1", "12345")
+    private val oppgave = OppgaveObjectMother.giveMeOppgave("2", "12345")
+    private val innboks = InnboksObjectMother.giveMeInnboks("3", "12345")
+    private val beskjed2 = BeskjedObjectMother.giveMeBeskjed("4", "12345")
     private val nokkel1 = createNokkel(1)
     private val nokkel2 = createNokkel(2)
     private val nokkel3 = createNokkel(3)

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksQueriesTest.kt
@@ -36,7 +36,7 @@ class InnboksQueriesTest {
     }
 
     private fun createInnboks(eventId: String, fodselsnummer: String): Innboks {
-        val innboks = InnboksObjectMother.createInnboks(eventId, fodselsnummer)
+        val innboks = InnboksObjectMother.giveMeInnboks(eventId, fodselsnummer)
 
         return runBlocking {
             database.dbQuery {

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveQueriesTest.kt
@@ -33,10 +33,10 @@ class OppgaveQueriesTest {
     }
 
     private fun createOppgave(eventId: String, fodselsnummer: String): Oppgave {
-        var oppgave = OppgaveObjectMother.createOppgave(eventId, fodselsnummer)
+        var oppgave = OppgaveObjectMother.giveMeOppgave(eventId, fodselsnummer)
         runBlocking {
             database.dbQuery {
-                var generatedId = createOppgave(oppgave).entityId
+                val generatedId = createOppgave(oppgave).entityId
                 oppgave = oppgave.copy(id=generatedId)
             }
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
+import no.nav.personbruker.dittnav.eventaggregator.done.Done
 import java.time.LocalDateTime
 
 data class Beskjed(
@@ -60,4 +61,11 @@ data class Beskjed(
                 "synligFremTil=$synligFremTil, " +
                 "aktiv=$aktiv"
     }
+
+    fun isRepresentsSameEvent(doneEvent: Done): Boolean {
+        return (eventId == doneEvent.eventId &&
+                produsent == doneEvent.produsent &&
+                fodselsnummer == doneEvent.fodselsnummer)
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedRepository.kt
@@ -24,4 +24,27 @@ class BeskjedRepository(private val database: Database) {
             }
         }
     }
+
+    suspend fun fetchAll(): List<Beskjed> {
+        var resultat = emptyList<Beskjed>()
+        database.queryWithExceptionTranslation {
+            resultat = getAllBeskjed()
+        }
+        if (resultat.isEmpty()) {
+            log.warn("Fant ingen beskjed-eventer i databasen")
+        }
+        return resultat
+    }
+
+    suspend fun fetchActive(): List<Beskjed> {
+        var resultat = emptyList<Beskjed>()
+        database.queryWithExceptionTranslation {
+            resultat = getAllBeskjedByAktiv(true)
+        }
+        if (resultat.isEmpty()) {
+            log.warn("Fant ingen aktive beskjed-eventer i databasen")
+        }
+        return resultat
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
@@ -35,9 +35,9 @@ class ApplicationContext {
     val innboksConsumer = KafkaConsumerSetup.setupConsumerForTheInnboksTopic(innboksKafkaProps, innboksEventProcessor)
 
     val doneRepository = DoneRepository(database)
-    val doneEventProcessor = DoneEventService(doneRepository, metricsProbe)
+    val doneEventProcessor = DoneEventService(doneRepository, beskjedRepository, innboksRepository, oppgaveRepository, metricsProbe)
     val doneKafkaProps = Kafka.consumerProps(environment, EventType.DONE)
     val doneConsumer = KafkaConsumerSetup.setupConsumerForTheDoneTopic(doneKafkaProps, doneEventProcessor)
 
-    val cachedDoneEventConsumer = CachedDoneEventConsumer(doneRepository)
+    val cachedDoneEventConsumer = CachedDoneEventConsumer(beskjedRepository, innboksRepository, oppgaveRepository, doneRepository)
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
@@ -5,12 +5,18 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.time.delay
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedRepository
+import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksRepository
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import kotlin.coroutines.CoroutineContext
 
 class CachedDoneEventConsumer(
+        private val beskjedRepository: BeskjedRepository,
+        private val innboksRepository: InnboksRepository,
+        private val oppgaveRepository: OppgaveRepository,
         private val doneRepository: DoneRepository,
         private val job: Job = Job()
 ) : CoroutineScope {
@@ -45,8 +51,10 @@ class CachedDoneEventConsumer(
     }
 
     private suspend fun groupDoneEventsByAssociatedEventType(allDone: List<Done>): DoneBatchProcessor {
-        val alleBrukernotifikasjoner = doneRepository.fetchBrukernotifikasjonerFromView()
-        val groupedDoneEvents = DoneBatchProcessor(alleBrukernotifikasjoner)
+        val allBeskjeder = beskjedRepository.fetchAll()
+        val allInnbokseventer = innboksRepository.fetchAll()
+        val allOppgaver = oppgaveRepository.fetchAll()
+        val groupedDoneEvents = DoneBatchProcessor(allBeskjeder, allInnbokseventer, allOppgaver)
         groupedDoneEvents.process(allDone)
         return groupedDoneEvents
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepository.kt
@@ -60,17 +60,6 @@ class DoneRepository(private val database: Database) {
         log.info("Har skrevet ${entities.size} done-eventer til vente-tabellen.")
     }
 
-    suspend fun fetchBrukernotifikasjonerFromView(): List<Brukernotifikasjon> {
-        var resultat = emptyList<Brukernotifikasjon>()
-        database.queryWithExceptionTranslation {
-            resultat = getAllBrukernotifikasjonFromView()
-        }
-        if (resultat.isEmpty()) {
-            log.warn("Fant ingen brukernotifikasjoner i databasen")
-        }
-        return resultat
-    }
-
     suspend fun fetchAllDoneEvents(): List<Done> {
         var resultat = emptyList<Done>()
         database.queryWithExceptionTranslation {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepository.kt
@@ -3,8 +3,6 @@ package no.nav.personbruker.dittnav.eventaggregator.done
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedRepository
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.setBeskjedAktivFlag
 import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
-import no.nav.personbruker.dittnav.eventaggregator.common.database.entity.Brukernotifikasjon
-import no.nav.personbruker.dittnav.eventaggregator.common.database.entity.getAllBrukernotifikasjonFromView
 import no.nav.personbruker.dittnav.eventaggregator.innboks.setInnboksAktivFlag
 import no.nav.personbruker.dittnav.eventaggregator.oppgave.setOppgaveAktivFlag
 import org.slf4j.Logger
@@ -15,6 +13,9 @@ class DoneRepository(private val database: Database) {
     val log: Logger = LoggerFactory.getLogger(BeskjedRepository::class.java)
 
     suspend fun writeDoneEventsForBeskjedToCache(entities: List<Done>) {
+        if (entities.isEmpty()) {
+            return
+        }
         database.queryWithExceptionTranslation {
             entities.forEach { entity ->
                 setBeskjedAktivFlag(entity.eventId, entity.produsent, entity.fodselsnummer, false)
@@ -24,6 +25,9 @@ class DoneRepository(private val database: Database) {
     }
 
     suspend fun writeDoneEventsForOppgaveToCache(entities: List<Done>) {
+        if (entities.isEmpty()) {
+            return
+        }
         database.queryWithExceptionTranslation {
             entities.forEach { entity ->
                 setOppgaveAktivFlag(entity.eventId, entity.produsent, entity.fodselsnummer, false)
@@ -33,6 +37,9 @@ class DoneRepository(private val database: Database) {
     }
 
     suspend fun writeDoneEventsForInnboksToCache(entities: List<Done>) {
+        if (entities.isEmpty()) {
+            return
+        }
         database.queryWithExceptionTranslation {
             entities.forEach { entity ->
                 setInnboksAktivFlag(entity.eventId, entity.produsent, entity.fodselsnummer, false)
@@ -42,13 +49,15 @@ class DoneRepository(private val database: Database) {
     }
 
     suspend fun writeDoneEventToCache(entities: List<Done>) {
+        if (entities.isEmpty()) {
+            return
+        }
         database.queryWithExceptionTranslation {
             entities.forEach { entity ->
                 createDoneEvent(entity)
             }
         }
-        val msg = "Har skrevet ${entities.size} done-eventer til vente-tabellen."
-        log.info(msg)
+        log.info("Har skrevet ${entities.size} done-eventer til vente-tabellen.")
     }
 
     suspend fun fetchBrukernotifikasjonerFromView(): List<Brukernotifikasjon> {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/Innboks.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/Innboks.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
+import no.nav.personbruker.dittnav.eventaggregator.done.Done
 import java.time.LocalDateTime
 
 data class Innboks (
@@ -54,4 +55,11 @@ data class Innboks (
                 "sistOppdatert=$sistOppdatert, " +
                 "aktiv=$aktiv"
     }
+
+    fun isRepresentsSameEvent(doneEvent: Done): Boolean {
+        return (eventId == doneEvent.eventId &&
+                produsent == doneEvent.produsent &&
+                fodselsnummer == doneEvent.fodselsnummer)
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksRepository.kt
@@ -25,4 +25,26 @@ class InnboksRepository(private val database: Database) {
 
     }
 
+    suspend fun fetchAll(): List<Innboks> {
+        var resultat = emptyList<Innboks>()
+        database.queryWithExceptionTranslation {
+            resultat = getAllInnboks()
+        }
+        if (resultat.isEmpty()) {
+            log.warn("Fant ingen innboks-eventer i databasen")
+        }
+        return resultat
+    }
+
+    suspend fun fetchActive(): List<Innboks> {
+        var resultat = emptyList<Innboks>()
+        database.queryWithExceptionTranslation {
+            resultat = getAllInnboksByAktiv(true)
+        }
+        if (resultat.isEmpty()) {
+            log.warn("Fant ingen aktive innboks-eventer i databasen")
+        }
+        return resultat
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
+import no.nav.personbruker.dittnav.eventaggregator.done.Done
 import java.time.LocalDateTime
 
 data class Oppgave(
@@ -53,4 +54,11 @@ data class Oppgave(
                 "sistOppdatert=$sistOppdatert, " +
                 "aktiv=$aktiv"
     }
+
+    fun isRepresentsSameEvent(doneEvent: Done): Boolean {
+        return (eventId == doneEvent.eventId &&
+                produsent == doneEvent.produsent &&
+                fodselsnummer == doneEvent.fodselsnummer)
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveRepository.kt
@@ -24,4 +24,27 @@ class OppgaveRepository(private val database: Database) {
         }
 
     }
+
+    suspend fun fetchAll(): List<Oppgave> {
+        var resultat = emptyList<Oppgave>()
+        database.queryWithExceptionTranslation {
+            resultat = getAllOppgave()
+        }
+        if (resultat.isEmpty()) {
+            log.warn("Fant ingen beskjed-eventer i databasen")
+        }
+        return resultat
+    }
+
+    suspend fun fetchActive(): List<Oppgave> {
+        var resultat = emptyList<Oppgave>()
+        database.queryWithExceptionTranslation {
+            resultat = getAllOppgaveByAktiv(true)
+        }
+        if (resultat.isEmpty()) {
+            log.warn("Fant ingen aktive oppgavae-eventer i databasen")
+        }
+        return resultat
+    }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventServiceTest.kt
@@ -4,8 +4,8 @@ import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.objectmother.ConsumerRecordsObjectMother
-import no.nav.personbruker.dittnav.eventaggregator.metrics.PrometheusMetricsCollector
 import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsProbe
+import no.nav.personbruker.dittnav.eventaggregator.metrics.PrometheusMetricsCollector
 import org.amshove.kluent.`should be`
 import org.amshove.kluent.`should throw`
 import org.amshove.kluent.invoking
@@ -99,7 +99,7 @@ class BeskjedEventServiceTest {
     private fun createANumberOfTransformedRecords(numberOfRecords: Int): MutableList<Beskjed> {
         val transformedRecords = mutableListOf<Beskjed>()
         for (i in 0 until numberOfRecords) {
-            transformedRecords.add(BeskjedObjectMother.createBeskjed("$i", "{$i}12345"))
+            transformedRecords.add(BeskjedObjectMother.giveMeBeskjed("$i", "{$i}12345"))
         }
         return transformedRecords
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
@@ -6,12 +6,16 @@ import kotlin.random.Random
 
 object BeskjedObjectMother {
 
-    fun createBeskjed(eventId: String, fodselsnummer: String): Beskjed {
-        val produsent = "DittNAV"
-        return createBeskjed(eventId, fodselsnummer, produsent)
+    fun giveMeBeskjed(): Beskjed {
+        return giveMeBeskjed("b-1", "123")
     }
 
-    fun createBeskjed(eventId: String, fodselsnummer: String, produsent: String): Beskjed {
+    fun giveMeBeskjed(eventId: String, fodselsnummer: String): Beskjed {
+        val produsent = "DittNAV"
+        return giveMeBeskjed(eventId, fodselsnummer, produsent)
+    }
+
+    fun giveMeBeskjed(eventId: String, fodselsnummer: String, produsent: String): Beskjed {
         return Beskjed(
                 uid = Random.nextInt(1,100).toString(),
                 produsent = produsent,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
@@ -1,16 +1,39 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
+import no.nav.personbruker.dittnav.eventaggregator.done.DoneObjectMother
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.junit.jupiter.api.Test
 
 class BeskjedTest {
 
+    private val expectedEventId = "b-1"
+    private val expectedFodselsnr = "1234"
+    private val expectedProdusent = "produsent-a"
+
     @Test
     fun `skal returnere maskerte data fra toString-metoden`() {
-        val beskjed = BeskjedObjectMother.createBeskjed("dummyEventId", "123")
+        val beskjed = BeskjedObjectMother.giveMeBeskjed("dummyEventId", "123")
         val beskjedAsString = beskjed.toString()
         beskjedAsString `should contain` "fodselsnummer=***"
         beskjedAsString `should contain` "tekst=***"
         beskjedAsString `should contain` "link=***"
     }
+
+    @Test
+    internal fun `skal match tilhorende done-event`() {
+        val beskjed = BeskjedObjectMother.giveMeBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
+        val matchendeDoneEvent = DoneObjectMother.createDone(expectedEventId, expectedProdusent, expectedFodselsnr)
+
+        beskjed.isRepresentsSameEvent(matchendeDoneEvent) `should be equal to` true
+    }
+
+    @Test
+    internal fun `skal ikke match med ikke-tilhorende done-eventer`() {
+        val beskjed = BeskjedObjectMother.giveMeBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
+        val ikkeMatchendeDoneEvent = DoneObjectMother.createDone("annenEventId", expectedProdusent, expectedFodselsnr)
+
+        beskjed.isRepresentsSameEvent(ikkeMatchendeDoneEvent) `should be equal to` false
+    }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneBatchProcessorTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneBatchProcessorTest.kt
@@ -1,6 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.objectmother.BrukernotifikasjonObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveObjectMother
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be`
 import org.junit.jupiter.api.Test
@@ -9,12 +11,17 @@ internal class DoneBatchProcessorTest {
 
     @Test
     fun `skal gruppere done-eventer etter hvilken event-type de tilhorer ut i fra en liste av brukernotifikasjoner`() {
-        val existingEntitiesInDatabase = BrukernotifikasjonObjectMother.giveMeOneOfEachEventType()
-        val doneEventsToProcess = DoneObjectMother.giveMeOneDoneEventForEach(existingEntitiesInDatabase)
-        val doneEventWithoutMatchingBeatification = DoneObjectMother.createDone("4")
-        doneEventsToProcess.add(doneEventWithoutMatchingBeatification)
+        val allBeskjed = listOf(BeskjedObjectMother.giveMeBeskjed())
+        val allInnboks = listOf(InnboksObjectMother.giveMeInnboks())
+        val allOppgave = listOf(OppgaveObjectMother.giveMeOppgave())
 
-        val processor = DoneBatchProcessor(existingEntitiesInDatabase)
+        val doneBeskjed = DoneObjectMother.giveMeMatchingDoneEvent(allBeskjed[0])
+        val doneInnboks = DoneObjectMother.giveMeMatchingDoneEvent(allInnboks[0])
+        val doneOppgave = DoneObjectMother.giveMeMatchingDoneEvent(allOppgave[0])
+        val doneEventWithoutMatchingBeatification = DoneObjectMother.createDone("4")
+        val doneEventsToProcess = listOf(doneBeskjed, doneInnboks, doneOppgave, doneEventWithoutMatchingBeatification)
+
+        val processor = DoneBatchProcessor(allBeskjed, allInnboks, allOppgave)
         processor.process(doneEventsToProcess)
 
         processor.foundBeskjed.size `should be` 1
@@ -31,7 +38,7 @@ internal class DoneBatchProcessorTest {
 
     @Test
     fun `skal haandtere at det ikke finnes eventer i databasen og at det ikke ble mottatt eventer`() {
-        val processor = DoneBatchProcessor(emptyList())
+        val processor = DoneBatchProcessor(emptyList(), emptyList(), emptyList())
 
         processor.process(emptyList())
 
@@ -43,8 +50,10 @@ internal class DoneBatchProcessorTest {
 
     @Test
     fun `skal haandtere at det ikke ble mottatt eventer`() {
-        val existingEntitiesInDatabase = BrukernotifikasjonObjectMother.giveMeOneOfEachEventType()
-        val processor = DoneBatchProcessor(existingEntitiesInDatabase)
+        val allBeskjed = listOf(BeskjedObjectMother.giveMeBeskjed())
+        val allInnboks = listOf(InnboksObjectMother.giveMeInnboks())
+        val allOppgave = listOf(OppgaveObjectMother.giveMeOppgave())
+        val processor = DoneBatchProcessor(allBeskjed, allInnboks, allOppgave)
 
         processor.process(emptyList())
 
@@ -56,7 +65,7 @@ internal class DoneBatchProcessorTest {
 
     @Test
     fun `skal haandtere at ingen av eventene ble funnet i databasen`() {
-        val processor = DoneBatchProcessor(emptyList())
+        val processor = DoneBatchProcessor(emptyList(), emptyList(), emptyList())
         val batchOfEntities = listOf(DoneObjectMother.createDone("1"), DoneObjectMother.createDone("2"))
 
         processor.process(batchOfEntities)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneBatchProcessorTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneBatchProcessorTest.kt
@@ -29,4 +29,42 @@ internal class DoneBatchProcessorTest {
         totalNumberOfGroupedEvents `should be equal to` doneEventsToProcess.size
     }
 
+    @Test
+    fun `skal haandtere at det ikke finnes eventer i databasen og at det ikke ble mottatt eventer`() {
+        val processor = DoneBatchProcessor(emptyList())
+
+        processor.process(emptyList())
+
+        processor.foundBeskjed.size `should be` 0
+        processor.foundInnboks.size `should be` 0
+        processor.foundOppgave.size `should be` 0
+        processor.notFoundEvents.size `should be` 0
+    }
+
+    @Test
+    fun `skal haandtere at det ikke ble mottatt eventer`() {
+        val existingEntitiesInDatabase = BrukernotifikasjonObjectMother.giveMeOneOfEachEventType()
+        val processor = DoneBatchProcessor(existingEntitiesInDatabase)
+
+        processor.process(emptyList())
+
+        processor.foundBeskjed.size `should be` 0
+        processor.foundInnboks.size `should be` 0
+        processor.foundOppgave.size `should be` 0
+        processor.notFoundEvents.size `should be` 0
+    }
+
+    @Test
+    fun `skal haandtere at ingen av eventene ble funnet i databasen`() {
+        val processor = DoneBatchProcessor(emptyList())
+        val batchOfEntities = listOf(DoneObjectMother.createDone("1"), DoneObjectMother.createDone("2"))
+
+        processor.process(batchOfEntities)
+
+        processor.foundBeskjed.size `should be` 0
+        processor.foundInnboks.size `should be` 0
+        processor.foundOppgave.size `should be` 0
+        processor.notFoundEvents.size `should be` 2
+    }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneObjectMother.kt
@@ -1,6 +1,9 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.Beskjed
 import no.nav.personbruker.dittnav.eventaggregator.common.database.entity.Brukernotifikasjon
+import no.nav.personbruker.dittnav.eventaggregator.innboks.Innboks
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.Oppgave
 import java.time.LocalDateTime
 import java.time.ZoneId
 
@@ -34,4 +37,29 @@ object DoneObjectMother {
         }
         return doneEvents
     }
+
+    fun giveMeMatchingDoneEvent(beskjedToMatch: Beskjed): Done {
+        return createDone(
+                beskjedToMatch.eventId,
+                beskjedToMatch.produsent,
+                beskjedToMatch.fodselsnummer
+        )
+    }
+
+    fun giveMeMatchingDoneEvent(innboksToMatch: Innboks): Done {
+        return createDone(
+                innboksToMatch.eventId,
+                innboksToMatch.produsent,
+                innboksToMatch.fodselsnummer
+        )
+    }
+
+    fun giveMeMatchingDoneEvent(oppgaveToMatch: Oppgave): Done {
+        return createDone(
+                oppgaveToMatch.eventId,
+                oppgaveToMatch.produsent,
+                oppgaveToMatch.fodselsnummer
+        )
+    }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventServiceTest.kt
@@ -97,7 +97,7 @@ class InnboksEventServiceTest {
 
     private fun createANumberOfTransformedInnboksRecords(number: Int): List<Innboks> {
         return (1..number).map {
-            InnboksObjectMother.createInnboks(it.toString(), "12345")
+            InnboksObjectMother.giveMeInnboks(it.toString(), "12345")
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
@@ -10,8 +10,12 @@ object InnboksObjectMother {
     }
 
     fun giveMeInnboks(eventId: String, fodselsnummer: String): Innboks {
+        return giveMeInnboks(eventId, fodselsnummer, "DittNAV")
+    }
+
+    fun giveMeInnboks(eventId: String, fodselsnummer: String, produsent: String): Innboks {
         return Innboks(
-                "DittNAV",
+                produsent,
                 eventId,
                 LocalDateTime.now(ZoneId.of("UTC")),
                 fodselsnummer,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
@@ -5,7 +5,11 @@ import java.time.ZoneId
 
 object InnboksObjectMother {
 
-    fun createInnboks(eventId: String, fodselsnummer: String): Innboks {
+    fun giveMeInnboks(): Innboks {
+        return giveMeInnboks("i-1", "123")
+    }
+
+    fun giveMeInnboks(eventId: String, fodselsnummer: String): Innboks {
         return Innboks(
                 "DittNAV",
                 eventId,
@@ -18,4 +22,5 @@ object InnboksObjectMother {
                 LocalDateTime.now(ZoneId.of("UTC")),
                 true)
     }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
@@ -31,10 +31,10 @@ class InnboksTest {
 
     @Test
     internal fun `skal ikke match med ikke-tilhorende done-eventer`() {
-        val beskjed = BeskjedObjectMother.giveMeBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
+        val innboks = InnboksObjectMother.giveMeInnboks(expectedEventId, expectedFodselsnr, expectedProdusent)
         val ikkeMatchendeDoneEvent = DoneObjectMother.createDone(expectedEventId, "annenProdusent", expectedFodselsnr)
 
-        beskjed.isRepresentsSameEvent(ikkeMatchendeDoneEvent) `should be equal to` false
+        innboks.isRepresentsSameEvent(ikkeMatchendeDoneEvent) `should be equal to` false
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
@@ -1,16 +1,40 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.done.DoneObjectMother
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.junit.jupiter.api.Test
 
 class InnboksTest {
 
+    private val expectedEventId = "i-1"
+    private val expectedFodselsnr = "1234"
+    private val expectedProdusent = "produsent-a"
+
     @Test
     fun `skal returnere maskerte data fra toString-metoden`() {
-        val innboks = InnboksObjectMother.createInnboks("dummyEventId", "123")
+        val innboks = InnboksObjectMother.giveMeInnboks("dummyEventId", "123")
         val innboksAsString = innboks.toString()
         innboksAsString `should contain` "fodselsnummer=***"
         innboksAsString `should contain` "tekst=***"
         innboksAsString `should contain` "link=***"
     }
+
+    @Test
+    internal fun `skal match tilhorende done-event`() {
+        val beskjed = BeskjedObjectMother.giveMeBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
+        val matchendeDoneEvent = DoneObjectMother.createDone(expectedEventId, expectedProdusent, expectedFodselsnr)
+
+        beskjed.isRepresentsSameEvent(matchendeDoneEvent) `should be equal to` true
+    }
+
+    @Test
+    internal fun `skal ikke match med ikke-tilhorende done-eventer`() {
+        val beskjed = BeskjedObjectMother.giveMeBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
+        val ikkeMatchendeDoneEvent = DoneObjectMother.createDone(expectedEventId, "annenProdusent", expectedFodselsnr)
+
+        beskjed.isRepresentsSameEvent(ikkeMatchendeDoneEvent) `should be equal to` false
+    }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventServiceTest.kt
@@ -98,7 +98,7 @@ class OppgaveEventServiceTest {
 
     private fun createANumberOfTransformedOppgaveRecords(number: Int): List<Oppgave> {
         return (1..number).map {
-            OppgaveObjectMother.createOppgave(it.toString(), "12345")
+            OppgaveObjectMother.giveMeOppgave(it.toString(), "12345")
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
@@ -5,7 +5,11 @@ import java.time.ZoneId
 
 object OppgaveObjectMother {
 
-    fun createOppgave(eventId: String, fodselsnummer: String): Oppgave {
+    fun giveMeOppgave(): Oppgave {
+        return giveMeOppgave("o-1", "123")
+    }
+
+    fun giveMeOppgave(eventId: String, fodselsnummer: String): Oppgave {
         return Oppgave(
                 produsent = "DittNAV",
                 eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC")),
@@ -18,4 +22,5 @@ object OppgaveObjectMother {
                 sistOppdatert = LocalDateTime.now(ZoneId.of("UTC")),
                 aktiv = true)
     }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
@@ -10,8 +10,12 @@ object OppgaveObjectMother {
     }
 
     fun giveMeOppgave(eventId: String, fodselsnummer: String): Oppgave {
+        return giveMeOppgave(eventId, fodselsnummer, "DittNAV")
+    }
+
+    fun giveMeOppgave(eventId: String, fodselsnummer: String, produsent: String): Oppgave {
         return Oppgave(
-                produsent = "DittNAV",
+                produsent = produsent,
                 eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC")),
                 fodselsnummer = fodselsnummer,
                 eventId = eventId,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
@@ -31,10 +31,10 @@ class OppgaveTest {
 
     @Test
     internal fun `skal ikke match med ikke-tilhorende done-eventer`() {
-        val beskjed = BeskjedObjectMother.giveMeBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
+        val oppgave = OppgaveObjectMother.giveMeOppgave(expectedEventId, expectedFodselsnr, expectedProdusent)
         val ikkeMatchendeDoneEvent = DoneObjectMother.createDone(expectedEventId, expectedProdusent, "7654")
 
-        beskjed.isRepresentsSameEvent(ikkeMatchendeDoneEvent) `should be equal to` false
+        oppgave.isRepresentsSameEvent(ikkeMatchendeDoneEvent) `should be equal to` false
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
@@ -1,16 +1,40 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.done.DoneObjectMother
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.junit.jupiter.api.Test
 
 class OppgaveTest {
 
+    private val expectedEventId = "o-1"
+    private val expectedFodselsnr = "1234"
+    private val expectedProdusent = "produsent-a"
+
     @Test
     fun `skal returnere maskerte data fra toString-metoden`() {
-        val oppgave = OppgaveObjectMother.createOppgave("dummyEventId", "123")
+        val oppgave = OppgaveObjectMother.giveMeOppgave("dummyEventId", "123")
         val oppgaveAsString = oppgave.toString()
         oppgaveAsString `should contain` "fodselsnummer=***"
         oppgaveAsString `should contain` "tekst=***"
         oppgaveAsString `should contain` "link=***"
     }
+
+    @Test
+    internal fun `skal match tilhorende done-event`() {
+        val beskjed = BeskjedObjectMother.giveMeBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
+        val matchendeDoneEvent = DoneObjectMother.createDone(expectedEventId, expectedProdusent, expectedFodselsnr)
+
+        beskjed.isRepresentsSameEvent(matchendeDoneEvent) `should be equal to` true
+    }
+
+    @Test
+    internal fun `skal ikke match med ikke-tilhorende done-eventer`() {
+        val beskjed = BeskjedObjectMother.giveMeBeskjed(expectedEventId, expectedFodselsnr, expectedProdusent)
+        val ikkeMatchendeDoneEvent = DoneObjectMother.createDone(expectedEventId, expectedProdusent, "7654")
+
+        beskjed.isRepresentsSameEvent(ikkeMatchendeDoneEvent) `should be equal to` false
+    }
+
 }


### PR DESCRIPTION
Hver gang det kommer inn et nytt done-event vil de bli forsøkt matchet opp mot aktive Beskjeder, Oppgaver eller Innboks-eventer. Hvis det skulle bli en bom, så havner eventet i ventetabellen. I prosesseringen av ventetabellen så vil det bli forsøkt å matches opp mot alle eventer, ikke kun de som er markert som aktive. Dette fører til at første gangsprosessering av done-eventer vil gå raskere.

PB-138. Ytelsestesting av DEA