### PR TITLE
Unngår propper på topic-ene pga feltelengdebegrensning i databasen

### DIFF
--- a/src/intTest/resources/logback.xml
+++ b/src/intTest/resources/logback.xml
@@ -1,12 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <configuration debug="true">
-    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
-
-    <property name="loggingPattern"
-              value="%d [%-5level] [%thread] %logger{5} %replace(- [%X{consumerId}, %X{callId}, %X{userId}] ){'- \[, , \] ',''}- %m%n"/>
-
-    <appender name="metrics" class="io.prometheus.client.logback.InstrumentedAppender"/>
-
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+        </encoder>
+    </appender>
     <root level="INFO">
-        <appender-ref ref="stdout_json"/>
+        <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
@@ -46,7 +46,7 @@ data class Beskjed(
             synligFremTil,
             aktiv
     ) {
-        validateNonNullFieldMaxLength(produsent, "systembruker", 100)
+        validateNonNullFieldMaxLength(produsent, "produsent", 100)
         validateNonNullFieldMaxLength(eventId, "eventId", 50)
         validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
         validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
@@ -1,5 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateMaxLength
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullFieldMaxLength
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateSikkerhetsnivaa
 import java.time.LocalDateTime
 
 data class Beskjed(
@@ -42,7 +45,16 @@ data class Beskjed(
             sistOppdatert,
             synligFremTil,
             aktiv
-    )
+    ) {
+        validateNonNullFieldMaxLength(produsent, "systembruker", 100)
+        validateNonNullFieldMaxLength(eventId, "eventId", 50)
+        validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
+        validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)
+        validateNonNullFieldMaxLength(tekst, "tekst", 500)
+        validateMaxLength(link, "link", 200)
+        validateSikkerhetsnivaa(sikkerhetsnivaa)
+        validateNonNullFieldMaxLength(uid, "uid", 100)
+    }
 
     override fun toString(): String {
         return "Beskjed(" +

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
@@ -4,6 +4,7 @@ import no.nav.brukernotifikasjon.schemas.Beskjed
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullKey
@@ -32,12 +33,19 @@ class BeskjedEventService(
                     successfullyTransformedEvents.add(internalEvent)
                     countSuccessfulEventForProducer(event.systembruker)
 
-                } catch (e: NokkelNullException) {
+                } catch (nne: NokkelNullException) {
                     countFailedEventForProducer(event.systembruker)
-                    log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", e)
-                } catch (e: FieldNullException) {
+                    log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", nne)
+
+                } catch (fne: FieldNullException) {
                     countFailedEventForProducer(event.systembruker)
-                    log.warn("Obligatorisk felt var tomt eller null. EventId: ${event.getNonNullKey().getEventId()}", e)
+                    log.warn("Obligatorisk felt var tomt eller null. EventId: ${event.getNonNullKey().getEventId()}, context: ${fne.context}", fne)
+
+                } catch (fve: FieldValidationException) {
+                    countFailedEventForProducer(event.systembruker)
+                    val eventId = event.getNonNullKey().getEventId()
+                    log.warn("Klarte ikke transformere eventet pga en valideringsfeil. EventId: $eventId, context: ${fve.context}", fve)
+
                 } catch (e: Exception) {
                     countFailedEventForProducer(event.systembruker)
                     problematicEvents.add(event)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
@@ -3,7 +3,6 @@ package no.nav.personbruker.dittnav.eventaggregator.beskjed
 import no.nav.brukernotifikasjon.schemas.Beskjed
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
@@ -36,10 +35,6 @@ class BeskjedEventService(
                 } catch (nne: NokkelNullException) {
                     countFailedEventForProducer(event.systembruker)
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", nne)
-
-                } catch (fne: FieldNullException) {
-                    countFailedEventForProducer(event.systembruker)
-                    log.warn("Obligatorisk felt var tomt eller null. EventId: ${event.getNonNullKey().getEventId()}, context: ${fne.context}", fne)
 
                 } catch (fve: FieldValidationException) {
                     countFailedEventForProducer(event.systembruker)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformer.kt
@@ -1,13 +1,17 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullField
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.util.UUID
+import java.util.*
 
 object BeskjedTransformer {
+
+    private val MAX_TEXT_FIELD_LENGTH = 500
 
     fun toInternal(externalNokkel: Nokkel, externalValue: no.nav.brukernotifikasjon.schemas.Beskjed): Beskjed {
         val newRecordsAreActiveByDefault = true
@@ -18,7 +22,7 @@ object BeskjedTransformer {
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(externalValue.getTidspunkt()), ZoneId.of("UTC")),
                 getNonNullField(externalValue.getFodselsnummer(), "Fødselsnummer"),
                 externalValue.getGrupperingsId(),
-                externalValue.getTekst(),
+                externalValue.getTekstIfValid(),
                 externalValue.getLink(),
                 externalValue.getSikkerhetsnivaa(),
                 LocalDateTime.now(ZoneId.of("UTC")),
@@ -30,6 +34,18 @@ object BeskjedTransformer {
 
     private fun no.nav.brukernotifikasjon.schemas.Beskjed.getAsUTDateTime(): LocalDateTime? {
         return getSynligFremTil()?.let { datetime -> LocalDateTime.ofInstant(Instant.ofEpochMilli(datetime), ZoneId.of("UTC")) }
+    }
+
+    private fun no.nav.brukernotifikasjon.schemas.Beskjed.getTekstIfValid(): String {
+        if(getTekst().isNullOrBlank()) {
+            throw FieldNullException("Feltet tekst må ha en verdi satt.")
+
+        } else if(getTekst().length > MAX_TEXT_FIELD_LENGTH) {
+            val fve = FieldValidationException("Feltet tekst kan ikke inneholde mer enn $MAX_TEXT_FIELD_LENGTH tegn.")
+            fve.addContext("rejectedField", getTekst())
+            throw fve
+        }
+        return getTekst()
     }
 
     private fun createRandomStringUUID(): String {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformer.kt
@@ -1,7 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullField
 import java.time.Instant
@@ -37,10 +36,10 @@ object BeskjedTransformer {
     }
 
     private fun no.nav.brukernotifikasjon.schemas.Beskjed.getTekstIfValid(): String {
-        if(getTekst().isNullOrBlank()) {
-            throw FieldNullException("Feltet tekst må ha en verdi satt.")
+        if (getTekst().isNullOrBlank()) {
+            throw FieldValidationException("Feltet tekst må ha en verdi satt, men var null eller blank.")
 
-        } else if(getTekst().length > MAX_TEXT_FIELD_LENGTH) {
+        } else if (getTekst().length > MAX_TEXT_FIELD_LENGTH) {
             val fve = FieldValidationException("Feltet tekst kan ikke inneholde mer enn $MAX_TEXT_FIELD_LENGTH tegn.")
             fve.addContext("rejectedField", getTekst())
             throw fve

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformer.kt
@@ -1,8 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
-import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullField
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.timestampToUTCDateOrNull
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -10,44 +9,31 @@ import java.util.*
 
 object BeskjedTransformer {
 
-    private val MAX_TEXT_FIELD_LENGTH = 500
+    private const val newRecordsAreActiveByDefault = true
 
     fun toInternal(externalNokkel: Nokkel, externalValue: no.nav.brukernotifikasjon.schemas.Beskjed): Beskjed {
-        val newRecordsAreActiveByDefault = true
-        val internal = Beskjed(
+        return Beskjed(
                 createRandomStringUUID(),
                 externalNokkel.getSystembruker(),
                 externalNokkel.getEventId(),
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(externalValue.getTidspunkt()), ZoneId.of("UTC")),
-                getNonNullField(externalValue.getFodselsnummer(), "Fødselsnummer"),
+                externalValue.getFodselsnummer(),
                 externalValue.getGrupperingsId(),
-                externalValue.getTekstIfValid(),
+                externalValue.getTekst(),
                 externalValue.getLink(),
                 externalValue.getSikkerhetsnivaa(),
                 LocalDateTime.now(ZoneId.of("UTC")),
-                externalValue.getAsUTDateTime(),
+                externalValue.synligFremTilAsUTCDateTime(),
                 newRecordsAreActiveByDefault
         )
-        return internal
-    }
-
-    private fun no.nav.brukernotifikasjon.schemas.Beskjed.getAsUTDateTime(): LocalDateTime? {
-        return getSynligFremTil()?.let { datetime -> LocalDateTime.ofInstant(Instant.ofEpochMilli(datetime), ZoneId.of("UTC")) }
-    }
-
-    private fun no.nav.brukernotifikasjon.schemas.Beskjed.getTekstIfValid(): String {
-        if (getTekst().isNullOrBlank()) {
-            throw FieldValidationException("Feltet tekst må ha en verdi satt, men var null eller blank.")
-
-        } else if (getTekst().length > MAX_TEXT_FIELD_LENGTH) {
-            val fve = FieldValidationException("Feltet tekst kan ikke inneholde mer enn $MAX_TEXT_FIELD_LENGTH tegn.")
-            fve.addContext("rejectedField", getTekst())
-            throw fve
-        }
-        return getTekst()
     }
 
     private fun createRandomStringUUID(): String {
         return UUID.randomUUID().toString()
     }
+
+    private fun no.nav.brukernotifikasjon.schemas.Beskjed.synligFremTilAsUTCDateTime(): LocalDateTime? {
+        return timestampToUTCDateOrNull(getSynligFremTil())
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/FieldNullException.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/FieldNullException.kt
@@ -1,5 +1,0 @@
-package no.nav.personbruker.dittnav.eventaggregator.common.exceptions
-
-class FieldNullException (message: String, cause: Throwable?) : FieldValidationException(message, cause) {
-    constructor(message: String) : this(message, null)
-}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/FieldValidationException.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/FieldValidationException.kt
@@ -1,5 +1,5 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.exceptions
 
-class FieldNullException (message: String, cause: Throwable?) : FieldValidationException(message, cause) {
+open class FieldValidationException (message: String, cause: Throwable?) : AbstractPersonbrukerException(message, cause) {
     constructor(message: String) : this(message, null)
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/serializer/nullCheck.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/serializer/nullCheck.kt
@@ -1,17 +1,9 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
-fun<T> ConsumerRecord<Nokkel, T>.getNonNullKey(): Nokkel {
-    return key()?: throw NokkelNullException()
-}
-
-fun getNonNullField(field: String, fieldName: String): String {
-    if(field.isNullOrBlank()) {
-        throw FieldValidationException("$fieldName var null eller tomt.")
-    }
-    return field
+fun <T> ConsumerRecord<Nokkel, T>.getNonNullKey(): Nokkel {
+    return key() ?: throw NokkelNullException()
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/serializer/nullCheck.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/serializer/nullCheck.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
@@ -11,7 +11,7 @@ fun<T> ConsumerRecord<Nokkel, T>.getNonNullKey(): Nokkel {
 
 fun getNonNullField(field: String, fieldName: String): String {
     if(field.isNullOrBlank()) {
-        throw FieldNullException("$fieldName var null eller tomt.")
+        throw FieldValidationException("$fieldName var null eller tomt.")
     }
     return field
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/validation/validationUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/validation/validationUtil.kt
@@ -1,0 +1,40 @@
+package no.nav.personbruker.dittnav.eventaggregator.common.validation
+
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+fun validateNonNullFieldMaxLength(field: String, fieldName: String, maxLength: Int): String {
+    validateNonNullField(field, fieldName)
+    return validateMaxLength(field, fieldName, maxLength)
+}
+
+fun validateMaxLength(field: String, fieldName: String, maxLength: Int): String {
+    if (field.length > maxLength) {
+        val fve = FieldValidationException("Feltet $fieldName kan ikke inneholde mer enn $maxLength tegn.")
+        fve.addContext("rejectedField", field)
+        throw fve
+    }
+    return field
+}
+
+fun validateNonNullField(field: String?, fieldName: String): String {
+    if (field.isNullOrBlank()) {
+        throw FieldValidationException("$fieldName var null eller tomt.")
+    }
+    return field
+}
+
+fun timestampToUTCDateOrNull(timestamp: Long): LocalDateTime {
+    return timestamp.let { datetime ->
+        LocalDateTime.ofInstant(Instant.ofEpochMilli(datetime), ZoneId.of("UTC"))
+    }
+}
+
+fun validateSikkerhetsnivaa(sikkerhetsnivaa: Int): Int {
+    return when (sikkerhetsnivaa) {
+        3, 4 -> sikkerhetsnivaa
+        else -> throw FieldValidationException("Sikkerhetsnivaa kan bare være 3 eller 4.")
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.done
 import no.nav.brukernotifikasjon.schemas.Done
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullKey
@@ -36,9 +36,9 @@ class DoneEventService(
                 } catch (e: NokkelNullException) {
                     countFailedEventForProducer(event.systembruker)
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", e)
-                } catch (e: FieldNullException) {
+                } catch (e: FieldValidationException) {
                     countFailedEventForProducer(event.systembruker)
-                    log.warn("Obligatorisk felt var tomt eller null. EventId: ${event.getNonNullKey().getEventId()}", e)
+                    log.warn("Eventet kan ikke brukes fordi det inneholder valideringsfeil, eventet vil bli forkastet. EventId: ${event.getNonNullKey().getEventId()}", e)
                 } catch (e: Exception) {
                     countFailedEventForProducer(event.systembruker)
                     problematicEvents.add(event)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTransformer.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullField
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullField
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -9,12 +9,11 @@ import java.time.ZoneId
 object DoneTransformer {
 
     fun toInternal(nokkel: Nokkel, external: no.nav.brukernotifikasjon.schemas.Done) : Done {
-        val internal = Done(nokkel.getSystembruker(),
+        return Done(nokkel.getSystembruker(),
                 nokkel.getEventId(),
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(external.getTidspunkt()), ZoneId.of("UTC")),
-                getNonNullField(external.getFodselsnummer(), "Fødselsnummer"),
+                validateNonNullField(external.getFodselsnummer(), "Fødselsnummer"),
                 external.getGrupperingsId()
         )
-        return internal
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/Innboks.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/Innboks.kt
@@ -42,7 +42,7 @@ data class Innboks (
             sistOppdatert,
             aktiv
     ) {
-        validateNonNullFieldMaxLength(produsent, "systembruker", 100)
+        validateNonNullFieldMaxLength(produsent, "produsent", 100)
         validateNonNullFieldMaxLength(eventId, "eventId", 50)
         validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
         validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/Innboks.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/Innboks.kt
@@ -1,5 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateMaxLength
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullFieldMaxLength
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateSikkerhetsnivaa
 import java.time.LocalDateTime
 
 data class Innboks (
@@ -38,7 +41,15 @@ data class Innboks (
             sikkerhetsnivaa,
             sistOppdatert,
             aktiv
-    )
+    ) {
+        validateNonNullFieldMaxLength(produsent, "systembruker", 100)
+        validateNonNullFieldMaxLength(eventId, "eventId", 50)
+        validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
+        validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)
+        validateNonNullFieldMaxLength(tekst, "tekst", 500)
+        validateMaxLength(link, "link", 200)
+        validateSikkerhetsnivaa(sikkerhetsnivaa)
+    }
 
     override fun toString(): String {
         return "Innboks(" +

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
@@ -34,9 +34,11 @@ class InnboksEventService (
                 } catch (e: NokkelNullException) {
                     countFailedEventForProducer(event.systembruker)
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", e)
+
                 } catch (e: FieldValidationException) {
                     countFailedEventForProducer(event.systembruker)
                     log.warn("Eventet kan ikke brukes fordi det inneholder valideringsfeil, eventet vil bli forkastet. EventId: ${event.getNonNullKey().getEventId()}", e)
+
                 } catch (e: Exception) {
                     countFailedEventForProducer(event.systembruker)
                     problematicEvents.add(event)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.innboks
 import no.nav.brukernotifikasjon.schemas.Innboks
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullKey
@@ -34,9 +34,9 @@ class InnboksEventService (
                 } catch (e: NokkelNullException) {
                     countFailedEventForProducer(event.systembruker)
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", e)
-                } catch (e: FieldNullException) {
+                } catch (e: FieldValidationException) {
                     countFailedEventForProducer(event.systembruker)
-                    log.warn("Obligatorisk felt var tomt eller null. EventId: ${event.getNonNullKey().getEventId()}", e)
+                    log.warn("Eventet kan ikke brukes fordi det inneholder valideringsfeil, eventet vil bli forkastet. EventId: ${event.getNonNullKey().getEventId()}", e)
                 } catch (e: Exception) {
                     countFailedEventForProducer(event.systembruker)
                     problematicEvents.add(event)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTransformer.kt
@@ -1,20 +1,21 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullField
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullField
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 object InnboksTransformer {
 
+    private const val newRecordsAreActiveByDefault = true
+
     fun toInternal(nokkel: Nokkel, external: no.nav.brukernotifikasjon.schemas.Innboks): Innboks {
-        val newRecordsAreActiveByDefault = true
         return Innboks(
                 nokkel.getSystembruker(),
                 nokkel.getEventId(),
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(external.getTidspunkt()), ZoneId.of("UTC")),
-                getNonNullField(external.getFodselsnummer(), "Fødselsnummer"),
+                validateNonNullField(external.getFodselsnummer(), "Fødselsnummer"),
                 external.getGrupperingsId(),
                 external.getTekst(),
                 external.getLink(),

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
@@ -1,5 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateMaxLength
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullFieldMaxLength
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateSikkerhetsnivaa
 import java.time.LocalDateTime
 
 data class Oppgave(
@@ -23,7 +26,7 @@ data class Oppgave(
             grupperingsId: String,
             tekst: String,
             link: String,
-            sikkerhetsinvaa: Int,
+            sikkerhetsnivaa: Int,
             sistOppdatert: LocalDateTime,
             aktiv: Boolean
     ) : this(null,
@@ -34,10 +37,18 @@ data class Oppgave(
             grupperingsId,
             tekst,
             link,
-            sikkerhetsinvaa,
+            sikkerhetsnivaa,
             sistOppdatert,
             aktiv
-    )
+    ) {
+        validateNonNullFieldMaxLength(produsent, "systembruker", 100)
+        validateNonNullFieldMaxLength(eventId, "eventId", 50)
+        validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
+        validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)
+        validateNonNullFieldMaxLength(tekst, "tekst", 500)
+        validateMaxLength(link, "link", 200)
+        validateSikkerhetsnivaa(sikkerhetsnivaa)
+    }
 
     override fun toString(): String {
         return "Oppgave(" +

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
@@ -41,7 +41,7 @@ data class Oppgave(
             sistOppdatert,
             aktiv
     ) {
-        validateNonNullFieldMaxLength(produsent, "systembruker", 100)
+        validateNonNullFieldMaxLength(produsent, "produsent", 100)
         validateNonNullFieldMaxLength(eventId, "eventId", 50)
         validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
         validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
@@ -34,9 +34,11 @@ class OppgaveEventService(
                 } catch (e: NokkelNullException) {
                     countFailedEventForProducer(event.systembruker)
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", e)
+
                 } catch (e: FieldValidationException) {
                     countFailedEventForProducer(event.systembruker)
                     log.warn("Eventet kan ikke brukes fordi det inneholder valideringsfeil, eventet vil bli forkastet. EventId: ${event.getNonNullKey().getEventId()}", e)
+
                 } catch (e: Exception) {
                     countFailedEventForProducer(event.systembruker)
                     problematicEvents.add(event)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.oppgave
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.brukernotifikasjon.schemas.Oppgave
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullKey
@@ -34,9 +34,9 @@ class OppgaveEventService(
                 } catch (e: NokkelNullException) {
                     countFailedEventForProducer(event.systembruker)
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", e)
-                } catch (e: FieldNullException) {
+                } catch (e: FieldValidationException) {
                     countFailedEventForProducer(event.systembruker)
-                    log.warn("Obligatorisk felt var tomt eller null. EventId: ${event.getNonNullKey().getEventId()}", e)
+                    log.warn("Eventet kan ikke brukes fordi det inneholder valideringsfeil, eventet vil bli forkastet. EventId: ${event.getNonNullKey().getEventId()}", e)
                 } catch (e: Exception) {
                     countFailedEventForProducer(event.systembruker)
                     problematicEvents.add(event)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTransformer.kt
@@ -1,20 +1,21 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullField
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullField
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 object OppgaveTransformer {
 
-    fun toInternal(nokkel: Nokkel, external : no.nav.brukernotifikasjon.schemas.Oppgave) : Oppgave {
-        val newRecordsAreActiveByDefault = true
-        val internal = Oppgave(
+    private const val newRecordsAreActiveByDefault = true
+
+    fun toInternal(nokkel: Nokkel, external: no.nav.brukernotifikasjon.schemas.Oppgave): Oppgave {
+        return Oppgave(
                 nokkel.getSystembruker(),
                 nokkel.getEventId(),
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(external.getTidspunkt()), ZoneId.of("UTC")),
-                getNonNullField(external.getFodselsnummer(), "Fødselsnummer"),
+                validateNonNullField(external.getFodselsnummer(), "Fødselsnummer"),
                 external.getGrupperingsId(),
                 external.getTekst(),
                 external.getLink(),
@@ -22,6 +23,5 @@ object OppgaveTransformer {
                 LocalDateTime.now(ZoneId.of("UTC")),
                 newRecordsAreActiveByDefault
         )
-        return internal
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/AvroBeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/AvroBeskjedObjectMother.kt
@@ -5,26 +5,30 @@ import java.time.Instant
 
 object AvroBeskjedObjectMother {
 
+    private val defaultLopenummer = 1
+    private val defaultFodselsnr = "12345"
+    private val defaultText = "Dette er Beskjed til brukeren"
+
     fun createBeskjedWithText(text: String): Beskjed {
-        return createBeskjed(1, "12345", text)
+        return createBeskjed(defaultLopenummer, defaultFodselsnr, text)
     }
 
-    fun createBeskjed(i: Int): Beskjed {
-        return createBeskjed(i, "12345", "Dette er Beskjed til brukeren")
+    fun createBeskjed(lopenummer: Int): Beskjed {
+        return createBeskjed(lopenummer, defaultFodselsnr, defaultText)
     }
 
     fun createBeskjedWithFodselsnummer(fodselsnummer: String): Beskjed {
-        return createBeskjed(1, fodselsnummer, "Dette er Beskjed til brukeren")
+        return createBeskjed(defaultLopenummer, fodselsnummer, defaultText)
     }
 
-    fun createBeskjed(i: Int, fodselsnummer: String, tekst: String): Beskjed {
+    fun createBeskjed(lopenummer: Int, fodselsnummer: String, text: String): Beskjed {
         return Beskjed(
                 Instant.now().toEpochMilli(),
                 Instant.now().toEpochMilli(),
                 fodselsnummer,
-                "100$i",
-                tekst,
-                "https://nav.no/systemX/$i",
+                "100$lopenummer",
+                text,
+                "https://nav.no/systemX/$lopenummer",
                 4)
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/AvroBeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/AvroBeskjedObjectMother.kt
@@ -5,24 +5,25 @@ import java.time.Instant
 
 object AvroBeskjedObjectMother {
 
-    fun createBeskjed(i: Int): Beskjed {
-        return Beskjed(
-                Instant.now().toEpochMilli(),
-                Instant.now().toEpochMilli(),
-                "12345",
-                "100$i",
-                "Dette er Beskjed til brukeren",
-                "https://nav.no/systemX/$i",
-                4)
+    fun createBeskjedWithText(text: String): Beskjed {
+        return createBeskjed(1, "12345", text)
     }
 
-    fun createBeskjed(i: Int, fodselsnummer: String): Beskjed {
+    fun createBeskjed(i: Int): Beskjed {
+        return createBeskjed(i, "12345", "Dette er Beskjed til brukeren")
+    }
+
+    fun createBeskjedWithFodselsnummer(fodselsnummer: String): Beskjed {
+        return createBeskjed(1, fodselsnummer, "Dette er Beskjed til brukeren")
+    }
+
+    fun createBeskjed(i: Int, fodselsnummer: String, tekst: String): Beskjed {
         return Beskjed(
                 Instant.now().toEpochMilli(),
                 Instant.now().toEpochMilli(),
                 fodselsnummer,
                 "100$i",
-                "Dette er Beskjed til brukeren",
+                tekst,
                 "https://nav.no/systemX/$i",
                 4)
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
+import no.nav.personbruker.dittnav.eventaggregator.common.`with message containing`
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import org.amshove.kluent.`should contain`
 import org.amshove.kluent.`should throw`
@@ -49,7 +50,7 @@ class BeskjedTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "produsent"
     }
 
     @Test
@@ -69,7 +70,7 @@ class BeskjedTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "fodselsnummer"
     }
 
     @Test
@@ -89,7 +90,7 @@ class BeskjedTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "eventId"
     }
 
     @Test
@@ -109,7 +110,7 @@ class BeskjedTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "grupperingsId"
     }
 
     @Test
@@ -129,7 +130,7 @@ class BeskjedTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "tekst"
     }
 
     @Test
@@ -149,7 +150,7 @@ class BeskjedTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "link"
     }
 
     @Test
@@ -169,7 +170,7 @@ class BeskjedTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = invalidSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "Sikkerhetsnivaa"
     }
 
     @Test
@@ -189,7 +190,7 @@ class BeskjedTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "uid"
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
@@ -1,9 +1,27 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import org.amshove.kluent.`should contain`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
+import kotlin.random.Random
 
 class BeskjedTest {
+
+    private val uid = Random.nextInt(1, 100).toString()
+    private val validProdusent = "DittNAV"
+    private val validFodselsnummer = "123"
+    private val eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC"))
+    private val synligFremTil = LocalDateTime.now(ZoneId.of("UTC"))
+    private val sistOppdatert = LocalDateTime.now(ZoneId.of("UTC"))
+    private val validEventId = "b-2"
+    private val validGrupperingsId = "65432"
+    private val validTekst = "Dette er en beskjed til brukeren"
+    private val validLink = "https://www.nav.no/systemX/"
+    private val validSikkerhetsnivaa = 4
 
     @Test
     fun `skal returnere maskerte data fra toString-metoden`() {
@@ -12,6 +30,166 @@ class BeskjedTest {
         beskjedAsString `should contain` "fodselsnummer=***"
         beskjedAsString `should contain` "tekst=***"
         beskjedAsString `should contain` "link=***"
+    }
+
+    @Test
+    fun `do not allow too long produsent`() {
+        val tooLongProdusent = "P".repeat(101)
+        invoking {
+            Beskjed(
+                    uid = uid,
+                    produsent = tooLongProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    synligFremTil = synligFremTil,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long fodselsnummer`() {
+        val tooLongFnr = "1".repeat(12)
+        invoking {
+            Beskjed(
+                    uid = uid,
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    synligFremTil = synligFremTil,
+                    fodselsnummer = tooLongFnr,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long eventid`() {
+        val tooLongEventId = "E".repeat(51)
+        invoking {
+            Beskjed(
+                    uid = uid,
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    synligFremTil = synligFremTil,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = tooLongEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long grupperingsId`() {
+        val tooLongGrupperingsId = "G".repeat(101)
+        invoking {
+            Beskjed(
+                    uid = uid,
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    synligFremTil = synligFremTil,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = tooLongGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long tekst`() {
+        val tooLongText = "T".repeat(501)
+        invoking {
+            Beskjed(
+                    uid = uid,
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    synligFremTil = synligFremTil,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = tooLongText,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long link`() {
+        val tooLongLink = "L".repeat(201)
+        invoking {
+            Beskjed(
+                    uid = uid,
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    synligFremTil = synligFremTil,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = tooLongLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow invalid sikkerhetsnivaa`() {
+        val invalidSikkerhetsnivaa = 2
+        invoking {
+            Beskjed(
+                    uid = uid,
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    synligFremTil = synligFremTil,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = invalidSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long uid`() {
+        val tooLongUid = "U".repeat(101)
+        invoking {
+            Beskjed(
+                    uid = tooLongUid,
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    synligFremTil = synligFremTil,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
@@ -1,7 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.*
@@ -37,7 +36,7 @@ class BeskjedTransformerTest {
     }
 
     @Test
-    fun `should throw FieldNullException when fodselsnummer is empty`() {
+    fun `should throw FieldValidationException when fodselsnummer is empty`() {
         val fodselsnummerEmpty = ""
         val event = AvroBeskjedObjectMother.createBeskjedWithFodselsnummer(fodselsnummerEmpty)
 
@@ -45,7 +44,7 @@ class BeskjedTransformerTest {
             runBlocking {
                 BeskjedTransformer.toInternal(dummyNokkel, event)
             }
-        } `should throw` FieldNullException::class
+        } `should throw` FieldValidationException::class
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kluentExtentions.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kluentExtentions.kt
@@ -1,0 +1,6 @@
+package no.nav.personbruker.dittnav.eventaggregator.common
+
+import org.amshove.kluent.ExceptionResult
+import org.amshove.kluent.shouldContain
+
+infix fun <T : Throwable> ExceptionResult<T>.`with message containing`(theMessage: String) = this.exceptionMessage shouldContain (theMessage)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
@@ -12,8 +12,8 @@ import org.apache.kafka.common.TopicPartition
 
 object ConsumerRecordsObjectMother {
 
-    fun giveMeConsumerRecordsWithThisConsumerRecord(concreteRecord : ConsumerRecord<Nokkel, Beskjed>): ConsumerRecords<Nokkel, Beskjed> {
-        val records = mutableMapOf<TopicPartition, List<ConsumerRecord<Nokkel, Beskjed>>>()
+    fun <T> giveMeConsumerRecordsWithThisConsumerRecord(concreteRecord: ConsumerRecord<Nokkel, T>): ConsumerRecords<Nokkel, T> {
+        val records = mutableMapOf<TopicPartition, List<ConsumerRecord<Nokkel, T>>>()
         records[TopicPartition(concreteRecord.topic(), 1)] = listOf(concreteRecord)
         return ConsumerRecords(records)
     }
@@ -35,9 +35,9 @@ object ConsumerRecordsObjectMother {
         return allRecords
     }
 
-    fun createConsumerRecord(topicName: String, beskjed: Beskjed): ConsumerRecord<Nokkel, Beskjed> {
+    fun <T> createConsumerRecord(topicName: String, actualEvent: T): ConsumerRecord<Nokkel, T> {
         val nokkel = createNokkel(1)
-        return ConsumerRecord(topicName, 1, 0, nokkel, beskjed)
+        return ConsumerRecord(topicName, 1, 0, nokkel, actualEvent)
     }
 
     fun giveMeANumberOfDoneRecords(numberOfRecords: Int, topicName: String): ConsumerRecords<Nokkel, Done> {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
@@ -12,6 +12,12 @@ import org.apache.kafka.common.TopicPartition
 
 object ConsumerRecordsObjectMother {
 
+    fun giveMeConsumerRecordsWithThisConsumerRecord(concreteRecord : ConsumerRecord<Nokkel, Beskjed>): ConsumerRecords<Nokkel, Beskjed> {
+        val records = mutableMapOf<TopicPartition, List<ConsumerRecord<Nokkel, Beskjed>>>()
+        records[TopicPartition(concreteRecord.topic(), 1)] = listOf(concreteRecord)
+        return ConsumerRecords(records)
+    }
+
     fun giveMeANumberOfBeskjedRecords(numberOfRecords: Int, topicName: String): ConsumerRecords<Nokkel, Beskjed> {
         val records = mutableMapOf<TopicPartition, List<ConsumerRecord<Nokkel, Beskjed>>>()
         val recordsForSingleTopic = createBeskjedRecords(topicName, numberOfRecords)
@@ -27,6 +33,11 @@ object ConsumerRecordsObjectMother {
             allRecords.add(ConsumerRecord(topicName, i, i.toLong(), nokkel, schemaRecord))
         }
         return allRecords
+    }
+
+    fun createConsumerRecord(topicName: String, beskjed: Beskjed): ConsumerRecord<Nokkel, Beskjed> {
+        val nokkel = createNokkel(1)
+        return ConsumerRecord(topicName, 1, 0, nokkel, beskjed)
     }
 
     fun giveMeANumberOfDoneRecords(numberOfRecords: Int, topicName: String): ConsumerRecords<Nokkel, Done> {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTransformerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.done.schema.AvroDoneObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.`should be equal to`
@@ -29,7 +29,7 @@ class DoneTransformerTest {
     }
 
     @Test
-    fun `should throw FieldNullException when fodselsnummer is empty`() {
+    fun `should throw FieldValidationException when fodselsnummer is empty`() {
         val fodselsnummer = ""
         val eventId = "123"
         val event = AvroDoneObjectMother.createDone(eventId, fodselsnummer)
@@ -39,6 +39,6 @@ class DoneTransformerTest {
             runBlocking {
                 DoneTransformer.toInternal(nokkel, event)
             }
-        } `should throw` FieldNullException::class
+        } `should throw` FieldValidationException::class
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/AvroInnboksObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/AvroInnboksObjectMother.kt
@@ -5,23 +5,29 @@ import java.time.Instant
 
 object AvroInnboksObjectMother {
 
-    fun createInnboks(i: Int): Innboks {
-        return Innboks(
-                Instant.now().toEpochMilli(),
-                "12345",
-                "100$i",
-                "Dette er innboksnotifikasjon til brukeren",
-                "https://nav.no/systemX/$i",
-                4)
+    private val defaultLopenummer = 1
+    private val defaultFodselsnummer = "12345"
+    private val defaultText = "Dette er innboksnotifikasjon til brukeren"
+
+    fun createInnboks(lopenummer: Int): Innboks {
+        return createInnboks(lopenummer, defaultFodselsnummer)
     }
 
-    fun createInnboks(i: Int, fodselsnummer: String): Innboks {
+    fun createInnboks(lopenummer: Int, fodselsnummer: String): Innboks {
+        return createInnboks(lopenummer, fodselsnummer, defaultText)
+    }
+
+    fun createInnboksWithText(text: String): Innboks {
+        return createInnboks(defaultLopenummer, defaultFodselsnummer, text)
+    }
+
+    fun createInnboks(lopenummer: Int, fodselsnummer: String, text: String): Innboks {
         return Innboks(
                 Instant.now().toEpochMilli(),
                 fodselsnummer,
-                "100$i",
-                "Dette er innboksnotifikasjon til brukeren",
-                "https://nav.no/systemX/$i",
+                "100$lopenummer",
+                text,
+                "https://nav.no/systemX/$lopenummer",
                 4)
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
+import no.nav.personbruker.dittnav.eventaggregator.common.`with message containing`
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import org.amshove.kluent.`should contain`
 import org.amshove.kluent.`should throw`
@@ -45,7 +46,7 @@ class InnboksTest {
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true
             )
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "produsent"
     }
 
     @Test
@@ -64,7 +65,7 @@ class InnboksTest {
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true
             )
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "fodselsnummer"
     }
 
     @Test
@@ -82,7 +83,7 @@ class InnboksTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "eventId"
     }
 
     @Test
@@ -100,7 +101,7 @@ class InnboksTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "grupperingsId"
     }
 
     @Test
@@ -118,7 +119,7 @@ class InnboksTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "tekst"
     }
 
     @Test
@@ -137,7 +138,7 @@ class InnboksTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "link"
     }
 
     @Test
@@ -155,7 +156,7 @@ class InnboksTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = invalidSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "Sikkerhetsnivaa"
     }
 
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
@@ -1,9 +1,24 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import org.amshove.kluent.`should contain`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class InnboksTest {
+
+    private val validProdusent = "DittNAV"
+    private val validFodselsnummer = "123"
+    private val eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC"))
+    private val sistOppdatert = LocalDateTime.now(ZoneId.of("UTC"))
+    private val validEventId = "b-2"
+    private val validGrupperingsId = "65432"
+    private val validTekst = "Dette er et innboks-event til brukeren"
+    private val validLink = "https://www.nav.no/systemX/"
+    private val validSikkerhetsnivaa = 4
 
     @Test
     fun `skal returnere maskerte data fra toString-metoden`() {
@@ -13,5 +28,135 @@ class InnboksTest {
         innboksAsString `should contain` "tekst=***"
         innboksAsString `should contain` "link=***"
     }
+
+    @Test
+    fun `do not allow too long produsent`() {
+        val tooLongProdusent = "P".repeat(101)
+        invoking {
+            Innboks(
+                    produsent = tooLongProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true
+            )
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long fodselsnummer`() {
+        val tooLongFnr = "1".repeat(12)
+        invoking {
+            Innboks(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = tooLongFnr,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true
+            )
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long eventid`() {
+        val tooLongEventId = "E".repeat(51)
+        invoking {
+            Innboks(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = tooLongEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long grupperingsId`() {
+        val tooLongGrupperingsId = "G".repeat(101)
+        invoking {
+            Innboks(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = tooLongGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long tekst`() {
+        val tooLongText = "T".repeat(501)
+        invoking {
+            Innboks(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = tooLongText,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long link`() {
+        val tooLongLink = "L".repeat(201)
+        invoking {
+            Innboks(
+
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = tooLongLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow invalid sikkerhetsnivaa`() {
+        val invalidSikkerhetsnivaa = 2
+        invoking {
+            Innboks(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = invalidSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTransformerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.*
 import org.junit.jupiter.api.Test
@@ -34,7 +34,7 @@ class InnboksTransformerTest {
     }
 
     @Test
-    fun `should throw FieldNullException when fodselsnummer is empty`() {
+    fun `should throw FieldValidationException when fodselsnummer is empty`() {
         val fodselsnummer = ""
         val eventId = 123
         val event = AvroInnboksObjectMother.createInnboks(eventId, fodselsnummer)
@@ -44,6 +44,6 @@ class InnboksTransformerTest {
             runBlocking {
                 InnboksTransformer.toInternal(nokkel, event)
             }
-        } `should throw` FieldNullException::class
+        } `should throw` FieldValidationException::class
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/AvroOppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/AvroOppgaveObjectMother.kt
@@ -5,23 +5,29 @@ import java.time.Instant
 
 object AvroOppgaveObjectMother {
 
-    fun createOppgave(i: Int): Oppgave {
-        return Oppgave(
-                Instant.now().toEpochMilli(),
-                "12345",
-                "100$i",
-                "Dette er oppgave til brukeren",
-                "https://nav.no/systemX/$i",
-                4)
+    private val defaultLopenummer = 1
+    private val defaultFodselsnr = "12345"
+    private val defaultTekst = "Dette er oppgave til brukeren"
+
+    fun createOppgave(lopenummer: Int): Oppgave {
+        return createOppgave(lopenummer, defaultFodselsnr, defaultTekst)
     }
 
-    fun createOppgave(i: Int, fodselsnummer: String): Oppgave {
+    fun createOppgave(lopenummer: Int, fodselsnummer: String): Oppgave {
+        return createOppgave(lopenummer, fodselsnummer, defaultTekst)
+    }
+
+    fun createOppgave(tekst: String): Oppgave {
+        return createOppgave(defaultLopenummer, defaultFodselsnr, tekst)
+    }
+
+    fun createOppgave(lopenummer: Int, fodselsnummer: String, tekst: String): Oppgave {
         return Oppgave(
                 Instant.now().toEpochMilli(),
                 fodselsnummer,
-                "100$i",
-                "Dette er oppgave til brukeren",
-                "https://nav.no/systemX/$i",
+                "100$lopenummer",
+                tekst,
+                "https://nav.no/systemX/$lopenummer",
                 4)
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
@@ -22,7 +22,7 @@ object OppgaveObjectMother {
                 grupperingsId = "Dok12345",
                 tekst = "Dette er en oppgave til brukeren",
                 link = "https://nav.no/systemX/",
-                sikkerhetsinvaa = 4,
+                sikkerhetsnivaa = 4,
                 sistOppdatert = LocalDateTime.now(ZoneId.of("UTC")),
                 aktiv = true)
     }
@@ -36,7 +36,7 @@ object OppgaveObjectMother {
                 grupperingsId = "Dok12345",
                 tekst = "Dette er en oppgave til brukeren",
                 link = "https://nav.no/systemX/",
-                sikkerhetsinvaa = 4,
+                sikkerhetsnivaa = 4,
                 sistOppdatert = LocalDateTime.now(ZoneId.of("UTC")),
                 aktiv = false)
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
@@ -1,9 +1,24 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import org.amshove.kluent.`should contain`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class OppgaveTest {
+
+    private val validProdusent = "DittNAV"
+    private val validFodselsnummer = "123"
+    private val eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC"))
+    private val sistOppdatert = LocalDateTime.now(ZoneId.of("UTC"))
+    private val validEventId = "b-2"
+    private val validGrupperingsId = "65432"
+    private val validTekst = "Dette er en oppgave til brukeren"
+    private val validLink = "https://www.nav.no/systemX/"
+    private val validSikkerhetsnivaa = 4
 
     @Test
     fun `skal returnere maskerte data fra toString-metoden`() {
@@ -12,6 +27,135 @@ class OppgaveTest {
         oppgaveAsString `should contain` "fodselsnummer=***"
         oppgaveAsString `should contain` "tekst=***"
         oppgaveAsString `should contain` "link=***"
+    }
+
+    @Test
+    fun `do not allow too long produsent`() {
+        val tooLongProdusent = "P".repeat(101)
+        invoking {
+            Oppgave(
+                    produsent = tooLongProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true
+            )
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long fodselsnummer`() {
+        val tooLongFnr = "1".repeat(12)
+        invoking {
+            Oppgave(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = tooLongFnr,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true
+            )
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long eventid`() {
+        val tooLongEventId = "E".repeat(51)
+        invoking {
+            Oppgave(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = tooLongEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long grupperingsId`() {
+        val tooLongGrupperingsId = "G".repeat(101)
+        invoking {
+            Oppgave(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = tooLongGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long tekst`() {
+        val tooLongText = "T".repeat(501)
+        invoking {
+            Oppgave(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = tooLongText,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow too long link`() {
+        val tooLongLink = "L".repeat(201)
+        invoking {
+            Oppgave(
+
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = tooLongLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
+    }
+
+    @Test
+    fun `do not allow invalid sikkerhetsnivaa`() {
+        val invalidSikkerhetsnivaa = 2
+        invoking {
+            Oppgave(
+                    produsent = validProdusent,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = validLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = invalidSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
+import no.nav.personbruker.dittnav.eventaggregator.common.`with message containing`
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import org.amshove.kluent.`should contain`
 import org.amshove.kluent.`should throw`
@@ -45,7 +46,7 @@ class OppgaveTest {
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true
             )
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "produsent"
     }
 
     @Test
@@ -64,7 +65,7 @@ class OppgaveTest {
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true
             )
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "fodselsnummer"
     }
 
     @Test
@@ -82,7 +83,7 @@ class OppgaveTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "eventId"
     }
 
     @Test
@@ -100,7 +101,7 @@ class OppgaveTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "grupperingsId"
     }
 
     @Test
@@ -118,7 +119,7 @@ class OppgaveTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "tekst"
     }
 
     @Test
@@ -137,7 +138,7 @@ class OppgaveTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "link"
     }
 
     @Test
@@ -155,7 +156,7 @@ class OppgaveTest {
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = invalidSikkerhetsnivaa,
                     aktiv = true)
-        } `should throw` FieldValidationException::class
+        } `should throw` FieldValidationException::class `with message containing` "Sikkerhetsnivaa"
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTransformerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldNullException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.*
 import org.junit.jupiter.api.Test
@@ -34,7 +34,7 @@ class OppgaveTransformerTest {
     }
 
     @Test
-    fun `should throw FieldNullException when fodselsnummer is empty`() {
+    fun `should throw FieldValidationException when fodselsnummer is empty`() {
         val fodselsnummer = ""
         val eventId = 1
         val event = AvroOppgaveObjectMother.createOppgave(eventId, fodselsnummer)
@@ -44,6 +44,6 @@ class OppgaveTransformerTest {
             runBlocking {
                 OppgaveTransformer.toInternal(nokkel, event)
             }
-        } `should throw` FieldNullException::class
+        } `should throw` FieldValidationException::class
     }
 }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,12 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <configuration debug="true">
-    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
-
-    <property name="loggingPattern"
-              value="%d [%-5level] [%thread] %logger{5} %replace(- [%X{consumerId}, %X{callId}, %X{userId}] ){'- \[, , \] ',''}- %m%n"/>
-
-    <appender name="metrics" class="io.prometheus.client.logback.InstrumentedAppender"/>
-
-    <root level="INFO">
-        <appender-ref ref="stdout_json"/>
-    </root>
+<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+        <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+    </encoder>
+</appender>
+<root level="INFO">
+    <appender-ref ref="STDOUT"/>
+</root>
 </configuration>


### PR DESCRIPTION
Lagt til validering på alle felter som har en lengdebegrensning i databasen for Beskjed, Innboks og Oppgave.
* Laget tester som sjekker valideringen av hvert felt.
* Laget tester som verifiserer at vi faktisk kvitterer ut eventer, med valideringsfeil, fra Kafka. Slik at det ikke oppstår propper på topic-en.

Det samme skal gjøres for Done-eventer, men det løses i en egen oppgave.