### PR TITLE
Gjort det tillatt å ikke spesifisere synligFremTil igjen

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/validation/validationUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/validation/validationUtil.kt
@@ -26,8 +26,8 @@ fun validateNonNullField(field: String?, fieldName: String): String {
     return field
 }
 
-fun timestampToUTCDateOrNull(timestamp: Long): LocalDateTime {
-    return timestamp.let { datetime ->
+fun timestampToUTCDateOrNull(timestamp: Long?): LocalDateTime? {
+    return timestamp?.let { datetime ->
         LocalDateTime.ofInstant(Instant.ofEpochMilli(datetime), ZoneId.of("UTC"))
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/AvroBeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/AvroBeskjedObjectMother.kt
@@ -32,4 +32,15 @@ object AvroBeskjedObjectMother {
                 4)
     }
 
+    fun createBeskjedWithotSynligFremTilSatt(): Beskjed {
+        return Beskjed(
+                Instant.now().toEpochMilli(),
+                null,
+                defaultFodselsnr,
+                "100$defaultLopenummer",
+                defaultText,
+                "https://nav.no/systemX/$defaultLopenummer",
+                4)
+    }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/AvroBeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/AvroBeskjedObjectMother.kt
@@ -32,7 +32,7 @@ object AvroBeskjedObjectMother {
                 4)
     }
 
-    fun createBeskjedWithotSynligFremTilSatt(): Beskjed {
+    fun createBeskjedWithoutSynligFremTilSatt(): Beskjed {
         return Beskjed(
                 Instant.now().toEpochMilli(),
                 null,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
@@ -81,4 +81,13 @@ class BeskjedTransformerTest {
         } `should throw` FieldValidationException::class
     }
 
+    @Test
+    fun `should allow synligFremTil to be null`() {
+        val beskjedUtenSynligTilSatt = AvroBeskjedObjectMother.createBeskjedWithotSynligFremTilSatt()
+
+        val transformed = BeskjedTransformer.toInternal(dummyNokkel, beskjedUtenSynligTilSatt)
+
+        transformed.synligFremTil.`should be null`()
+    }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
@@ -83,7 +83,7 @@ class BeskjedTransformerTest {
 
     @Test
     fun `should allow synligFremTil to be null`() {
-        val beskjedUtenSynligTilSatt = AvroBeskjedObjectMother.createBeskjedWithotSynligFremTilSatt()
+        val beskjedUtenSynligTilSatt = AvroBeskjedObjectMother.createBeskjedWithoutSynligFremTilSatt()
 
         val transformed = BeskjedTransformer.toInternal(dummyNokkel, beskjedUtenSynligTilSatt)
 


### PR DESCRIPTION
Rettet feil som gjorde at det ikke lengre var gyldig å droppe å sette feltet synligFremTil.

Har lagt til en test som framprovoser feilen, slik at dette ikke oppstår igjen.