### PR TITLE
PB-390 - Prevalidering av Done-eventer

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedQueriesTest.kt
@@ -16,7 +16,7 @@ class BeskjedQueriesTest {
     private val Beskjed3: Beskjed
     private val Beskjed4: Beskjed
 
-    private val produsent = "DittNAV"
+    private val produsent = "dummyProducer"
     private val fodselsnummer = "12345"
     private val eventId = "2"
 

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumerTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumerTest.kt
@@ -24,7 +24,7 @@ class CachedDoneEventConsumerTest {
     private val doneRepository = DoneRepository(database)
     private val eventConsumer = CachedDoneEventConsumer(doneRepository)
 
-    private val produsent = "DittNAV"
+    private val produsent = "dummyProducer"
     private val fodselsnummer = "12345"
     private val beskjed1 = BeskjedObjectMother.giveMeAktivBeskjed("1", fodselsnummer, produsent)
     private val oppgave1 = OppgaveObjectMother.giveMeAktivOppgave("2", fodselsnummer, produsent)

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksQueriesTest.kt
@@ -20,7 +20,7 @@ class InnboksQueriesTest {
     private val innboks2: Innboks
     private val innboks3: Innboks
 
-    private val produsent = "DittNAV"
+    private val produsent = "dummyProducer"
     private val eventId = "1"
 
     private val allInnboks: List<Innboks>

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveQueriesTest.kt
@@ -18,7 +18,7 @@ class OppgaveQueriesTest {
     private val oppgave2: Oppgave
     private val oppgave3: Oppgave
 
-    private val produsent = "DittNAV"
+    private val produsent = "dummyProducer"
     private val eventId = "2"
 
     private val allEvents: List<Oppgave>

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
@@ -33,7 +33,7 @@ class BeskjedEventService(
                     countSuccessfulEventForProducer(event.systembruker)
 
                 } catch (nne: NokkelNullException) {
-                    countFailedEventForProducer(event.systembruker)
+                    countFailedEventForProducer("NoProducerSpecified")
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", nne)
 
                 } catch (fve: FieldValidationException) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/NokkelNullException.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/NokkelNullException.kt
@@ -1,5 +1,5 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.exceptions
 
-import java.lang.Exception
-
-class NokkelNullException: Exception() {}
+class NokkelNullException(message: String, cause: Throwable?) : AbstractPersonbrukerException(message, cause) {
+    constructor(message: String) : this(message, null)
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/serializer/nullCheck.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/serializer/nullCheck.kt
@@ -5,5 +5,5 @@ import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullE
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
 fun <T> ConsumerRecord<Nokkel, T>.getNonNullKey(): Nokkel {
-    return key() ?: throw NokkelNullException()
+    return key() ?: throw NokkelNullException("Produsenten har ikke spesifisert en kafka-key for sitt event")
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/validation/validationUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/validation/validationUtil.kt
@@ -5,6 +5,20 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 
+private val fodselsnummerRegEx = """[\d]{1,11}""".toRegex()
+
+fun validateFodselsnummer(field: String): String {
+    validateNonNullField(field, "fødselsnummer")
+    if (isNotValidFodselsnummer(field)) {
+        val fve = FieldValidationException("Feltet fodselsnummer kan kun innholde siffer, og maks antall er 11.")
+        fve.addContext("rejectedFieldValue", field)
+        throw fve
+    }
+    return field
+}
+
+private fun isNotValidFodselsnummer(field: String) = !fodselsnummerRegEx.matches(field)
+
 fun validateNonNullFieldMaxLength(field: String, fieldName: String, maxLength: Int): String {
     validateNonNullField(field, fieldName)
     return validateMaxLength(field, fieldName, maxLength)
@@ -13,7 +27,7 @@ fun validateNonNullFieldMaxLength(field: String, fieldName: String, maxLength: I
 fun validateMaxLength(field: String, fieldName: String, maxLength: Int): String {
     if (field.length > maxLength) {
         val fve = FieldValidationException("Feltet $fieldName kan ikke inneholde mer enn $maxLength tegn.")
-        fve.addContext("rejectedField", field)
+        fve.addContext("rejectedFieldValue", field)
         throw fve
     }
     return field

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/Done.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/Done.kt
@@ -1,5 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateFodselsnummer
+import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullFieldMaxLength
 import java.time.LocalDateTime
 
 data class Done(
@@ -9,6 +11,13 @@ data class Done(
         val fodselsnummer: String,
         val grupperingsId: String
 ) {
+
+    init {
+        validateNonNullFieldMaxLength(produsent, "produsent", 100)
+        validateNonNullFieldMaxLength(eventId, "eventId", 50)
+        validateFodselsnummer(fodselsnummer)
+    }
+
     override fun toString(): String {
         return "Done(" +
                 "produsent=$produsent, " +

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
@@ -34,11 +34,13 @@ class DoneEventService(
                     countSuccessfulEventForProducer(event.systembruker)
 
                 } catch (e: NokkelNullException) {
-                    countFailedEventForProducer(event.systembruker)
+                    countFailedEventForProducer("NoProducerSpecified")
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", e)
+
                 } catch (e: FieldValidationException) {
                     countFailedEventForProducer(event.systembruker)
                     log.warn("Eventet kan ikke brukes fordi det inneholder valideringsfeil, eventet vil bli forkastet. EventId: ${event.getNonNullKey().getEventId()}", e)
+
                 } catch (e: Exception) {
                     countFailedEventForProducer(event.systembruker)
                     problematicEvents.add(event)
@@ -53,7 +55,7 @@ class DoneEventService(
         kastExceptionHvisMislykkedeTransformasjoner(problematicEvents)
     }
 
-    private suspend fun groupDoneEventsByAssociatedEventType(successfullyTransformedEvents: MutableList<no.nav.personbruker.dittnav.eventaggregator.done.Done>): DoneBatchProcessor {
+    private suspend fun groupDoneEventsByAssociatedEventType(successfullyTransformedEvents: List<no.nav.personbruker.dittnav.eventaggregator.done.Done>): DoneBatchProcessor {
         val aktiveBrukernotifikasjoner = doneRepository.fetchActiveBrukernotifikasjonerFromView()
         val batch = DoneBatchProcessor(aktiveBrukernotifikasjoner)
         batch.process(successfullyTransformedEvents)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTransformer.kt
@@ -1,18 +1,17 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullField
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 object DoneTransformer {
 
-    fun toInternal(nokkel: Nokkel, external: no.nav.brukernotifikasjon.schemas.Done) : Done {
+    fun toInternal(nokkel: Nokkel, external: no.nav.brukernotifikasjon.schemas.Done): Done {
         return Done(nokkel.getSystembruker(),
                 nokkel.getEventId(),
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(external.getTidspunkt()), ZoneId.of("UTC")),
-                validateNonNullField(external.getFodselsnummer(), "Fødselsnummer"),
+                external.getFodselsnummer(),
                 external.getGrupperingsId()
         )
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
@@ -32,7 +32,7 @@ class InnboksEventService (
                     countSuccessfulEventForProducer(event.systembruker)
 
                 } catch (e: NokkelNullException) {
-                    countFailedEventForProducer(event.systembruker)
+                    countFailedEventForProducer("NoProducerSpecified")
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", e)
 
                 } catch (e: FieldValidationException) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
@@ -32,7 +32,7 @@ class OppgaveEventService(
                     countSuccessfulEventForProducer(event.systembruker)
 
                 } catch (e: NokkelNullException) {
-                    countFailedEventForProducer(event.systembruker)
+                    countFailedEventForProducer("NoProducerSpecified")
                     log.warn("Eventet manglet nøkkel. Topic: ${event.topic()}, Partition: ${event.partition()}, Offset: ${event.offset()}", e)
 
                 } catch (e: FieldValidationException) {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
@@ -11,7 +11,7 @@ object BeskjedObjectMother {
     }
 
     fun giveMeAktivBeskjed(eventId: String, fodselsnummer: String): Beskjed {
-        val produsent = "DittNAV"
+        val produsent = "dummyProducer"
         return giveMeAktivBeskjed(eventId, fodselsnummer, produsent)
     }
 
@@ -33,8 +33,8 @@ object BeskjedObjectMother {
 
     fun giveMeInaktivBeskjed(): Beskjed {
         return Beskjed(
-                uid = Random.nextInt(1,100).toString(),
-                produsent = "DittNAV",
+                uid = Random.nextInt(1, 100).toString(),
+                produsent = "dummyProducer",
                 eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC")),
                 synligFremTil = LocalDateTime.now(ZoneId.of("UTC")),
                 fodselsnummer = "123",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
@@ -13,7 +13,7 @@ import kotlin.random.Random
 class BeskjedTest {
 
     private val uid = Random.nextInt(1, 100).toString()
-    private val validProdusent = "DittNAV"
+    private val validProdusent = "dummyProducer"
     private val validFodselsnummer = "123"
     private val eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC"))
     private val synligFremTil = LocalDateTime.now(ZoneId.of("UTC"))

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/BrukernotifikasjonObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/BrukernotifikasjonObjectMother.kt
@@ -16,12 +16,24 @@ object BrukernotifikasjonObjectMother {
         return Brukernotifikasjon("b-1", "dummyProducer", EventType.BESKJED, "123")
     }
 
+    fun giveMeBeskjed(fodselsnummer: String): Brukernotifikasjon {
+        return Brukernotifikasjon("b-1", "dummyProducer", EventType.BESKJED, fodselsnummer)
+    }
+
     fun giveMeInnboks(): Brukernotifikasjon {
         return Brukernotifikasjon("i-1", "dummyProducer", EventType.INNBOKS, "123")
     }
 
+    fun giveMeInnboks(fodselsnummer: String): Brukernotifikasjon {
+        return Brukernotifikasjon("i-1", "dummyProducer", EventType.INNBOKS, fodselsnummer)
+    }
+
     fun giveMeOppgave(): Brukernotifikasjon {
         return Brukernotifikasjon("o-1", "dummyProducer", EventType.OPPGAVE, "123")
+    }
+
+    fun giveMeOppgave(fodselsnummer: String): Brukernotifikasjon {
+        return Brukernotifikasjon("o-1", "dummyProducer", EventType.OPPGAVE, fodselsnummer)
     }
 
     fun giveMeFor(beskjed: Beskjed): Brukernotifikasjon {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
@@ -2,6 +2,7 @@ package no.nav.personbruker.dittnav.eventaggregator.common.objectmother
 
 import no.nav.brukernotifikasjon.schemas.*
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.common.database.entity.Brukernotifikasjon
 import no.nav.personbruker.dittnav.eventaggregator.done.schema.AvroDoneObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.innboks.AvroInnboksObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
@@ -11,6 +12,20 @@ import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.common.TopicPartition
 
 object ConsumerRecordsObjectMother {
+
+    fun createMatchingRecords(entitiesInDbToMatch: List<Brukernotifikasjon>): ConsumerRecords<Nokkel, Done> {
+        val listOfConsumerRecord = mutableListOf<ConsumerRecord<Nokkel, Done>>()
+        entitiesInDbToMatch.forEach { entity ->
+            val done = AvroDoneObjectMother.createDoneRecord(entity.eventId, entity.fodselsnummer)
+            listOfConsumerRecord.add(done)
+        }
+        return giveMeConsumerRecordsWithThisConsumerRecord(listOfConsumerRecord)
+    }
+
+    fun createMatchingRecords(entityInDbToMatch: Brukernotifikasjon): ConsumerRecords<Nokkel, Done> {
+        val matchingDoneEvent = AvroDoneObjectMother.createDoneRecord(entityInDbToMatch.eventId, entityInDbToMatch.fodselsnummer)
+        return giveMeConsumerRecordsWithThisConsumerRecord(matchingDoneEvent)
+    }
 
     fun <T> giveMeConsumerRecordsWithThisConsumerRecord(listOfConcreteRecords: List<ConsumerRecord<Nokkel, T>>): ConsumerRecords<Nokkel, T> {
         val records = mutableMapOf<TopicPartition, List<ConsumerRecord<Nokkel, T>>>()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
@@ -12,6 +12,12 @@ import org.apache.kafka.common.TopicPartition
 
 object ConsumerRecordsObjectMother {
 
+    fun <T> giveMeConsumerRecordsWithThisConsumerRecord(listOfConcreteRecords: List<ConsumerRecord<Nokkel, T>>): ConsumerRecords<Nokkel, T> {
+        val records = mutableMapOf<TopicPartition, List<ConsumerRecord<Nokkel, T>>>()
+        records[TopicPartition(listOfConcreteRecords[0].topic(), 1)] = listOfConcreteRecords
+        return ConsumerRecords(records)
+    }
+
     fun <T> giveMeConsumerRecordsWithThisConsumerRecord(concreteRecord: ConsumerRecord<Nokkel, T>): ConsumerRecords<Nokkel, T> {
         val records = mutableMapOf<TopicPartition, List<ConsumerRecord<Nokkel, T>>>()
         records[TopicPartition(concreteRecord.topic(), 1)] = listOf(concreteRecord)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
@@ -54,7 +54,8 @@ class DoneEventServiceTest {
         val beskjedInDbToMatch = BrukernotifikasjonObjectMother.giveMeBeskjed(dummyFnr)
         val records = createMatchingRecords(beskjedInDbToMatch)
 
-        val capturedNumberOfBeskjedEntitiesWrittenToTheDb = captureBeskjedEventsWrittenToDb()
+        val capturedNumberOfBeskjedEntitiesWrittenToTheDb = slot<List<Done>>()
+        coEvery { repository.writeDoneEventsForBeskjedToCache(capture(capturedNumberOfBeskjedEntitiesWrittenToTheDb)) } returns Unit
 
         coEvery {
             repository.fetchActiveBrukernotifikasjonerFromView()
@@ -77,7 +78,8 @@ class DoneEventServiceTest {
         val innboksEventInDbToMatch = BrukernotifikasjonObjectMother.giveMeInnboks(dummyFnr)
         val records = createMatchingRecords(innboksEventInDbToMatch)
 
-        val capturedNumberOfInnboksEntitiesWrittenToTheDb = captureInnboksEventsWrittenToDb()
+        val capturedNumberOfInnboksEntitiesWrittenToTheDb = slot<List<Done>>()
+        coEvery { repository.writeDoneEventsForInnboksToCache(capture(capturedNumberOfInnboksEntitiesWrittenToTheDb)) } returns Unit
 
         coEvery {
             repository.fetchActiveBrukernotifikasjonerFromView()
@@ -100,7 +102,8 @@ class DoneEventServiceTest {
         val oppgaveEventInDbToMatch = BrukernotifikasjonObjectMother.giveMeOppgave(dummyFnr)
         val records = createMatchingRecords(oppgaveEventInDbToMatch)
 
-        val capturedNumberOfOppgaveEntitiesWrittenToTheDb = captureOppgaveEventsWrittenToDb()
+        val capturedNumberOfOppgaveEntitiesWrittenToTheDb = slot<List<Done>>()
+        coEvery { repository.writeDoneEventsForOppgaveToCache(capture(capturedNumberOfOppgaveEntitiesWrittenToTheDb)) } returns Unit
 
         coEvery {
             repository.fetchActiveBrukernotifikasjonerFromView()
@@ -145,7 +148,8 @@ class DoneEventServiceTest {
         val doneEvent = AvroDoneObjectMother.createDoneRecord("eventIdUteMatch", beskjedInDbToMatch.fodselsnummer)
         val records = ConsumerRecordsObjectMother.giveMeConsumerRecordsWithThisConsumerRecord(doneEvent)
 
-        val capturedNumberOfDoneWrittenToTheDb = captureNumberOfDoneEntitiesWrittenToTheDb()
+        val capturedNumberOfDoneWrittenToTheDb = slot<List<Done>>()
+        coEvery { repository.writeDoneEventToCache(capture(capturedNumberOfDoneWrittenToTheDb)) } returns Unit
 
         coEvery {
             repository.fetchActiveBrukernotifikasjonerFromView()
@@ -171,7 +175,8 @@ class DoneEventServiceTest {
         val entitiesInDbToMatch = listOf(beskjedInDbToMatch1, beskjedInDbToMatch2, beskjedInDbToMatch3)
         val records = createMatchingRecords(entitiesInDbToMatch)
 
-        val capturedNumberOfBeskjedEntitiesWrittenToTheDb = captureBeskjedEventsWrittenToDb()
+        val capturedNumberOfBeskjedEntitiesWrittenToTheDb = slot<List<Done>>()
+        coEvery { repository.writeDoneEventsForBeskjedToCache(capture(capturedNumberOfBeskjedEntitiesWrittenToTheDb)) } returns Unit
 
         val simulertFeil = UntransformableRecordException("Simulert feil")
         val matchingDoneEvent2 = DoneObjectMother.giveMeMatchingDoneEvent(beskjedInDbToMatch2)
@@ -231,30 +236,6 @@ class DoneEventServiceTest {
     private fun createMatchingRecords(entityInDbToMatch: Brukernotifikasjon): ConsumerRecords<Nokkel, no.nav.brukernotifikasjon.schemas.Done> {
         val matchingDoneEvent = AvroDoneObjectMother.createDoneRecord(entityInDbToMatch.eventId, entityInDbToMatch.fodselsnummer)
         return ConsumerRecordsObjectMother.giveMeConsumerRecordsWithThisConsumerRecord(matchingDoneEvent)
-    }
-
-    private fun captureNumberOfDoneEntitiesWrittenToTheDb(): CapturingSlot<List<Done>> {
-        val capturedNumberOfDoneWrittenToTheDb = slot<List<Done>>()
-        coEvery { repository.writeDoneEventToCache(capture(capturedNumberOfDoneWrittenToTheDb)) } returns Unit
-        return capturedNumberOfDoneWrittenToTheDb
-    }
-
-    private fun captureBeskjedEventsWrittenToDb(): CapturingSlot<List<Done>> {
-        val numberOfEntities = slot<List<Done>>()
-        coEvery { repository.writeDoneEventsForBeskjedToCache(capture(numberOfEntities)) } returns Unit
-        return numberOfEntities
-    }
-
-    private fun captureInnboksEventsWrittenToDb(): CapturingSlot<List<Done>> {
-        val numberOfEntities = slot<List<Done>>()
-        coEvery { repository.writeDoneEventsForInnboksToCache(capture(numberOfEntities)) } returns Unit
-        return numberOfEntities
-    }
-
-    private fun captureOppgaveEventsWrittenToDb(): CapturingSlot<List<Done>> {
-        val numberOfEntities = slot<List<Done>>()
-        coEvery { repository.writeDoneEventsForOppgaveToCache(capture(numberOfEntities)) } returns Unit
-        return numberOfEntities
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
@@ -34,10 +34,10 @@ class DoneEventServiceTest {
         clearMocks(repository)
         clearMocks(metricsProbe)
         clearMocks(metricsSession)
-        mockSlikAtRunninMetricsAlltidKjores()
+        mockSlikAtInnholdetIRunWithMetricsAlltidKjores()
     }
 
-    private fun mockSlikAtRunninMetricsAlltidKjores() {
+    private fun mockSlikAtInnholdetIRunWithMetricsAlltidKjores() {
         val slot = slot<suspend EventMetricsSession.() -> Unit>()
         coEvery { metricsProbe.runWithMetrics(any(), capture(slot)) } coAnswers {
             slot.captured.invoke(metricsSession)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
@@ -2,19 +2,16 @@ package no.nav.personbruker.dittnav.eventaggregator.done
 
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
-import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.database.entity.Brukernotifikasjon
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.objectmother.BrukernotifikasjonObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.common.objectmother.ConsumerRecordsObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.common.objectmother.ConsumerRecordsObjectMother.createMatchingRecords
 import no.nav.personbruker.dittnav.eventaggregator.done.schema.AvroDoneObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsSession
 import org.amshove.kluent.`should be`
 import org.amshove.kluent.`should throw`
 import org.amshove.kluent.invoking
-import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -29,15 +26,15 @@ class DoneEventServiceTest {
     private val dummyFnr = "1".repeat(11)
 
     @BeforeEach
-    private fun resetMocks() {
+    private fun `reset mocks`() {
         mockkObject(DoneTransformer)
         clearMocks(repository)
         clearMocks(metricsProbe)
         clearMocks(metricsSession)
-        mockSlikAtInnholdetIRunWithMetricsAlltidKjores()
+        `mock slik at innholdet i runWithMetrics alltid kjores`()
     }
 
-    private fun mockSlikAtInnholdetIRunWithMetricsAlltidKjores() {
+    private fun `mock slik at innholdet i runWithMetrics alltid kjores`() {
         val slot = slot<suspend EventMetricsSession.() -> Unit>()
         coEvery { metricsProbe.runWithMetrics(any(), capture(slot)) } coAnswers {
             slot.captured.invoke(metricsSession)
@@ -45,7 +42,7 @@ class DoneEventServiceTest {
     }
 
     @AfterAll
-    private fun cleanUp() {
+    private fun `clean up`() {
         unmockkAll()
     }
 
@@ -222,20 +219,6 @@ class DoneEventServiceTest {
         coVerify(exactly = 1) { repository.writeDoneEventsForBeskjedToCache(emptyList()) }
         coVerify(exactly = 1) { repository.writeDoneEventsForInnboksToCache(emptyList()) }
         coVerify(exactly = 1) { repository.writeDoneEventsForOppgaveToCache(emptyList()) }
-    }
-
-    private fun createMatchingRecords(entitiesInDbToMatch: List<Brukernotifikasjon>): ConsumerRecords<Nokkel, no.nav.brukernotifikasjon.schemas.Done> {
-        val listOfConsumerRecord = mutableListOf<ConsumerRecord<Nokkel, no.nav.brukernotifikasjon.schemas.Done>>()
-        entitiesInDbToMatch.forEach { entity ->
-            val done = AvroDoneObjectMother.createDoneRecord(entity.eventId, entity.fodselsnummer)
-            listOfConsumerRecord.add(done)
-        }
-        return ConsumerRecordsObjectMother.giveMeConsumerRecordsWithThisConsumerRecord(listOfConsumerRecord)
-    }
-
-    private fun createMatchingRecords(entityInDbToMatch: Brukernotifikasjon): ConsumerRecords<Nokkel, no.nav.brukernotifikasjon.schemas.Done> {
-        val matchingDoneEvent = AvroDoneObjectMother.createDoneRecord(entityInDbToMatch.eventId, entityInDbToMatch.fodselsnummer)
-        return ConsumerRecordsObjectMother.giveMeConsumerRecordsWithThisConsumerRecord(matchingDoneEvent)
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
@@ -1,0 +1,260 @@
+package no.nav.personbruker.dittnav.eventaggregator.done
+
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.personbruker.dittnav.eventaggregator.common.database.entity.Brukernotifikasjon
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
+import no.nav.personbruker.dittnav.eventaggregator.common.objectmother.BrukernotifikasjonObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.common.objectmother.ConsumerRecordsObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.done.schema.AvroDoneObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsProbe
+import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsSession
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DoneEventServiceTest {
+
+    private val repository = mockk<DoneRepository>(relaxed = true)
+    private val metricsProbe = mockk<EventMetricsProbe>(relaxed = true)
+    private val metricsSession = mockk<EventMetricsSession>(relaxed = true)
+    private val service = DoneEventService(repository, metricsProbe)
+
+    private val dummyFnr = "1".repeat(11)
+
+    @BeforeEach
+    private fun resetMocks() {
+        mockkObject(DoneTransformer)
+        clearMocks(repository)
+        clearMocks(metricsProbe)
+        clearMocks(metricsSession)
+        mockSlikAtRunninMetricsAlltidKjores()
+    }
+
+    private fun mockSlikAtRunninMetricsAlltidKjores() {
+        val slot = slot<suspend EventMetricsSession.() -> Unit>()
+        coEvery { metricsProbe.runWithMetrics(any(), capture(slot)) } coAnswers {
+            slot.captured.invoke(metricsSession)
+        }
+    }
+
+    @AfterAll
+    private fun cleanUp() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `skal oppdatere beskjed-eventer som det blir funnet match for`() {
+        val beskjedInDbToMatch = BrukernotifikasjonObjectMother.giveMeBeskjed(dummyFnr)
+        val records = createMatchingRecords(beskjedInDbToMatch)
+
+        val capturedNumberOfBeskjedEntitiesWrittenToTheDb = captureBeskjedEventsWrittenToDb()
+
+        coEvery {
+            repository.fetchActiveBrukernotifikasjonerFromView()
+        } returns listOf(beskjedInDbToMatch)
+
+        runBlocking {
+            service.processEvents(records)
+        }
+
+        capturedNumberOfBeskjedEntitiesWrittenToTheDb.captured.size `should be` 1
+
+        coVerify(exactly = 1) { repository.writeDoneEventsForBeskjedToCache(any()) }
+        coVerify(exactly = 1) { repository.writeDoneEventToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForInnboksToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForOppgaveToCache(emptyList()) }
+    }
+
+    @Test
+    fun `skal oppdatere innboks-eventer som det blir funnet match for`() {
+        val innboksEventInDbToMatch = BrukernotifikasjonObjectMother.giveMeInnboks(dummyFnr)
+        val records = createMatchingRecords(innboksEventInDbToMatch)
+
+        val capturedNumberOfInnboksEntitiesWrittenToTheDb = captureInnboksEventsWrittenToDb()
+
+        coEvery {
+            repository.fetchActiveBrukernotifikasjonerFromView()
+        } returns listOf(innboksEventInDbToMatch)
+
+        runBlocking {
+            service.processEvents(records)
+        }
+
+        capturedNumberOfInnboksEntitiesWrittenToTheDb.captured.size `should be` 1
+
+        coVerify(exactly = 1) { repository.writeDoneEventsForInnboksToCache(any()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForBeskjedToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForOppgaveToCache(emptyList()) }
+    }
+
+    @Test
+    fun `skal oppdatere oppgave-eventer som det blir funnet match for`() {
+        val oppgaveEventInDbToMatch = BrukernotifikasjonObjectMother.giveMeOppgave(dummyFnr)
+        val records = createMatchingRecords(oppgaveEventInDbToMatch)
+
+        val capturedNumberOfOppgaveEntitiesWrittenToTheDb = captureOppgaveEventsWrittenToDb()
+
+        coEvery {
+            repository.fetchActiveBrukernotifikasjonerFromView()
+        } returns listOf(oppgaveEventInDbToMatch)
+
+        runBlocking {
+            service.processEvents(records)
+        }
+
+        capturedNumberOfOppgaveEntitiesWrittenToTheDb.captured.size `should be` 1
+
+        coVerify(exactly = 1) { repository.writeDoneEventsForOppgaveToCache(any()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForInnboksToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForBeskjedToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventToCache(emptyList()) }
+    }
+
+    @Test
+    fun `skal ignorere event med ugyldig nokkel`() {
+        val beskjedEventInDbToMatch = BrukernotifikasjonObjectMother.giveMeBeskjed(dummyFnr)
+        val matchingDoneEvent = AvroDoneObjectMother.createDone(beskjedEventInDbToMatch.eventId)
+        val doneEventWithoutKey = AvroDoneObjectMother.createDoneRecord(null, matchingDoneEvent)
+        val records = ConsumerRecordsObjectMother.giveMeConsumerRecordsWithThisConsumerRecord(doneEventWithoutKey)
+
+        coEvery {
+            repository.fetchActiveBrukernotifikasjonerFromView()
+        } returns listOf(beskjedEventInDbToMatch)
+
+        runBlocking {
+            service.processEvents(records)
+        }
+
+        coVerify(exactly = 1) { repository.writeDoneEventToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForOppgaveToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForInnboksToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForBeskjedToCache(emptyList()) }
+    }
+
+    @Test
+    fun `skal skrive done-eventer det ikke blir funnet match for inn i ventetabellen`() {
+        val beskjedInDbToMatch = BrukernotifikasjonObjectMother.giveMeBeskjed(dummyFnr)
+        val doneEvent = AvroDoneObjectMother.createDoneRecord("eventIdUteMatch", beskjedInDbToMatch.fodselsnummer)
+        val records = ConsumerRecordsObjectMother.giveMeConsumerRecordsWithThisConsumerRecord(doneEvent)
+
+        val capturedNumberOfDoneWrittenToTheDb = captureNumberOfDoneEntitiesWrittenToTheDb()
+
+        coEvery {
+            repository.fetchActiveBrukernotifikasjonerFromView()
+        } returns listOf(beskjedInDbToMatch)
+
+        runBlocking {
+            service.processEvents(records)
+        }
+
+        capturedNumberOfDoneWrittenToTheDb.captured.size `should be` 1
+
+        coVerify(exactly = 1) { repository.writeDoneEventToCache(any()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForBeskjedToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForInnboksToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForOppgaveToCache(emptyList()) }
+    }
+
+    @Test
+    fun `skal kaste exception hvis det skjer minst en ukjent feil`() {
+        val beskjedInDbToMatch1 = BrukernotifikasjonObjectMother.giveMeBeskjed(dummyFnr)
+        val beskjedInDbToMatch2 = BrukernotifikasjonObjectMother.giveMeBeskjed(dummyFnr)
+        val beskjedInDbToMatch3 = BrukernotifikasjonObjectMother.giveMeBeskjed(dummyFnr)
+        val entitiesInDbToMatch = listOf(beskjedInDbToMatch1, beskjedInDbToMatch2, beskjedInDbToMatch3)
+        val records = createMatchingRecords(entitiesInDbToMatch)
+
+        val capturedNumberOfBeskjedEntitiesWrittenToTheDb = captureBeskjedEventsWrittenToDb()
+
+        val simulertFeil = UntransformableRecordException("Simulert feil")
+        val matchingDoneEvent2 = DoneObjectMother.giveMeMatchingDoneEvent(beskjedInDbToMatch2)
+        val matchingDoneEvent3 = DoneObjectMother.giveMeMatchingDoneEvent(beskjedInDbToMatch3)
+        val matchingDoneEvents = listOf(matchingDoneEvent2, matchingDoneEvent3)
+        every {
+            DoneTransformer.toInternal(any(), any())
+        } throws simulertFeil andThenMany matchingDoneEvents
+
+        coEvery {
+            repository.fetchActiveBrukernotifikasjonerFromView()
+        } returns listOf(beskjedInDbToMatch2, beskjedInDbToMatch3)
+
+        invoking {
+            runBlocking {
+                service.processEvents(records)
+            }
+        } `should throw` UntransformableRecordException::class
+
+        capturedNumberOfBeskjedEntitiesWrittenToTheDb.captured.size `should be` 2
+
+        coVerify(exactly = 1) { repository.writeDoneEventsForBeskjedToCache(any()) }
+        coVerify(exactly = 1) { repository.writeDoneEventToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForInnboksToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForOppgaveToCache(emptyList()) }
+    }
+
+    @Test
+    fun `skal forkaste eventer som har valideringsfeil`() {
+        val tooLongFodselsnr = "1".repeat(12)
+        val beskjedInDbToMatch = BrukernotifikasjonObjectMother.giveMeBeskjed(tooLongFodselsnr)
+        val records = createMatchingRecords(beskjedInDbToMatch)
+
+        coEvery {
+            repository.fetchActiveBrukernotifikasjonerFromView()
+        } returns listOf(beskjedInDbToMatch)
+
+        runBlocking {
+            service.processEvents(records)
+        }
+
+        coVerify(exactly = 1) { repository.writeDoneEventToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForBeskjedToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForInnboksToCache(emptyList()) }
+        coVerify(exactly = 1) { repository.writeDoneEventsForOppgaveToCache(emptyList()) }
+    }
+
+    private fun createMatchingRecords(entitiesInDbToMatch: List<Brukernotifikasjon>): ConsumerRecords<Nokkel, no.nav.brukernotifikasjon.schemas.Done> {
+        val listOfConsumerRecord = mutableListOf<ConsumerRecord<Nokkel, no.nav.brukernotifikasjon.schemas.Done>>()
+        entitiesInDbToMatch.forEach { entity ->
+            val done = AvroDoneObjectMother.createDoneRecord(entity.eventId, entity.fodselsnummer)
+            listOfConsumerRecord.add(done)
+        }
+        return ConsumerRecordsObjectMother.giveMeConsumerRecordsWithThisConsumerRecord(listOfConsumerRecord)
+    }
+
+    private fun createMatchingRecords(entityInDbToMatch: Brukernotifikasjon): ConsumerRecords<Nokkel, no.nav.brukernotifikasjon.schemas.Done> {
+        val matchingDoneEvent = AvroDoneObjectMother.createDoneRecord(entityInDbToMatch.eventId, entityInDbToMatch.fodselsnummer)
+        return ConsumerRecordsObjectMother.giveMeConsumerRecordsWithThisConsumerRecord(matchingDoneEvent)
+    }
+
+    private fun captureNumberOfDoneEntitiesWrittenToTheDb(): CapturingSlot<List<Done>> {
+        val capturedNumberOfDoneWrittenToTheDb = slot<List<Done>>()
+        coEvery { repository.writeDoneEventToCache(capture(capturedNumberOfDoneWrittenToTheDb)) } returns Unit
+        return capturedNumberOfDoneWrittenToTheDb
+    }
+
+    private fun captureBeskjedEventsWrittenToDb(): CapturingSlot<List<Done>> {
+        val numberOfEntities = slot<List<Done>>()
+        coEvery { repository.writeDoneEventsForBeskjedToCache(capture(numberOfEntities)) } returns Unit
+        return numberOfEntities
+    }
+
+    private fun captureInnboksEventsWrittenToDb(): CapturingSlot<List<Done>> {
+        val numberOfEntities = slot<List<Done>>()
+        coEvery { repository.writeDoneEventsForInnboksToCache(capture(numberOfEntities)) } returns Unit
+        return numberOfEntities
+    }
+
+    private fun captureOppgaveEventsWrittenToDb(): CapturingSlot<List<Done>> {
+        val numberOfEntities = slot<List<Done>>()
+        coEvery { repository.writeDoneEventsForOppgaveToCache(capture(numberOfEntities)) } returns Unit
+        return numberOfEntities
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneObjectMother.kt
@@ -7,7 +7,7 @@ import java.time.ZoneId
 object DoneObjectMother {
 
     fun giveMeDone(eventId: String): Done {
-        val produsent = "DittNAV"
+        val produsent = "dummyProducer"
         val fodselsnummer = "12345"
         return giveMeDone(eventId, produsent, fodselsnummer)
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/schema/AvroDoneObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/schema/AvroDoneObjectMother.kt
@@ -1,9 +1,34 @@
 package no.nav.personbruker.dittnav.eventaggregator.done.schema
 
 import no.nav.brukernotifikasjon.schemas.Done
+import no.nav.brukernotifikasjon.schemas.Nokkel
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import java.time.Instant
 
 object AvroDoneObjectMother {
+
+    private val defaultOffset = 0L
+    private val defaultPartition = 0
+    private val defaultDummtTopicName = "dummy"
+
+    fun createDoneRecord(eventId: String, fodselsnr: String): ConsumerRecord<Nokkel, Done> {
+        val key = Nokkel("dummyProducer", eventId)
+        val value = Done(
+                Instant.now().toEpochMilli(),
+                fodselsnr,
+                "100${eventId}"
+        )
+        return ConsumerRecord(defaultDummtTopicName, defaultPartition, defaultOffset, key, value)
+    }
+
+    fun createDoneRecord(key: Nokkel?, value: Done): ConsumerRecord<Nokkel, Done> {
+        return if (key != null) {
+            ConsumerRecord(defaultDummtTopicName, defaultPartition, defaultOffset, key, value)
+
+        } else {
+            ConsumerRecord<Nokkel, Done>(defaultDummtTopicName, defaultPartition, defaultOffset, null, value)
+        }
+    }
 
     fun createDone(eventId: String): Done {
         return Done(

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
@@ -10,7 +10,7 @@ object InnboksObjectMother {
     }
 
     fun giveMeAktivInnboks(eventId: String, fodselsnummer: String): Innboks {
-        return giveMeAktivInnboks(eventId, fodselsnummer, "DittNAV")
+        return giveMeAktivInnboks(eventId, fodselsnummer, "dummyProducer")
     }
 
     fun giveMeAktivInnboks(eventId: String, fodselsnummer: String, produsent: String): Innboks {
@@ -29,7 +29,7 @@ object InnboksObjectMother {
 
     fun giveMeInaktivInnboks(): Innboks {
         return Innboks(
-                "DittNAV",
+                "dummyProducer",
                 "76543",
                 LocalDateTime.now(ZoneId.of("UTC")),
                 "123",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
@@ -11,7 +11,7 @@ import java.time.ZoneId
 
 class InnboksTest {
 
-    private val validProdusent = "DittNAV"
+    private val validProdusent = "dummyProducer"
     private val validFodselsnummer = "123"
     private val eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC"))
     private val sistOppdatert = LocalDateTime.now(ZoneId.of("UTC"))

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/nokkel/nokkelObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/nokkel/nokkelObjectMother.kt
@@ -2,4 +2,4 @@ package no.nav.personbruker.dittnav.eventaggregator.nokkel
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
 
-fun createNokkel(eventId: Int): Nokkel = Nokkel("DittNAV", eventId.toString())
+fun createNokkel(eventId: Int): Nokkel = Nokkel("dummyProducer", eventId.toString())

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
@@ -10,7 +10,7 @@ object OppgaveObjectMother {
     }
 
     fun giveMeAktivOppgave(eventId: String, fodselsnummer: String): Oppgave {
-        return giveMeAktivOppgave(eventId, fodselsnummer, "DittNAV")
+        return giveMeAktivOppgave(eventId, fodselsnummer, "dummyProducer")
     }
 
     fun giveMeAktivOppgave(eventId: String, fodselsnummer: String, produsent: String): Oppgave {
@@ -29,7 +29,7 @@ object OppgaveObjectMother {
 
     fun giveMeInaktivOppgave(): Oppgave {
         return Oppgave(
-                produsent = "DittNAV",
+                produsent = "dummyProducer",
                 eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC")),
                 fodselsnummer = "123",
                 eventId = "o-2",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
@@ -11,7 +11,7 @@ import java.time.ZoneId
 
 class OppgaveTest {
 
-    private val validProdusent = "DittNAV"
+    private val validProdusent = "dummyProducer"
     private val validFodselsnummer = "123"
     private val eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC"))
     private val sistOppdatert = LocalDateTime.now(ZoneId.of("UTC"))


### PR DESCRIPTION
* Lagt til prevalidering av feltene for done-eventer, slik at vi unngår feil mot databasen pga feltlengder.
* Lagt til full testdekning på behandlingen av done-eventer.
* I tilfeller hvor det skjer en NokkelNullException vil man ikke kunne hente ut en systembruker, fordi dette feltet ligger i Nokkel som jo ikke har noen verdi.

PB-390. Feilhåndtering hvis ett event i en batch ikke validerer