### PR TITLE
Logging av status etter prosessering av done-eventer

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
@@ -59,7 +59,7 @@ class CachedDoneEventConsumer(
         val groupedDoneEvents = fetchActiveEvents()
         groupedDoneEvents.process(allDone)
         updateTheDatabase(groupedDoneEvents)
-
+        log.info("Status for prosessering av done-eventer, opp mot aktive eventer:\n$groupedDoneEvents")
         return groupedDoneEvents
     }
 
@@ -78,7 +78,7 @@ class CachedDoneEventConsumer(
     private suspend fun processDeactivatedEventsOnly(remainingEventsToLookFor: List<Done>): DoneBatchProcessor {
         val groupedDoneEvents = fetchInactiveEvents()
         groupedDoneEvents.process(remainingEventsToLookFor)
-
+        log.info("Status for prosessering av done-eventer, opp mot deaktive eventer:\n$groupedDoneEvents")
         return groupedDoneEvents
     }
 


### PR DESCRIPTION
Dette gjøres for å nå i en periode lettere kunne følge med på hvordan det faktisk går med prosesseringen av done-eventer.