### PR TITLE
Del en av retting av at done-tabellen ikke blir tømt ved treff

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
@@ -78,6 +78,7 @@ class CachedDoneEventConsumer(
     private suspend fun processDeactivatedEventsOnly(remainingEventsToLookFor: List<Done>): DoneBatchProcessor {
         val groupedDoneEvents = fetchInactiveEvents()
         groupedDoneEvents.process(remainingEventsToLookFor)
+        updateTheDatabase(groupedDoneEvents)
         log.info("Status for prosessering av done-eventer, opp mot deaktive eventer:\n$groupedDoneEvents")
         return groupedDoneEvents
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
@@ -79,7 +79,7 @@ class CachedDoneEventConsumer(
         val groupedDoneEvents = fetchInactiveEvents()
         groupedDoneEvents.process(remainingEventsToLookFor)
         updateTheDatabase(groupedDoneEvents)
-        log.info("Status for prosessering av done-eventer, opp mot deaktive eventer:\n$groupedDoneEvents")
+        log.info("Status for prosessering av done-eventer, opp mot deaktiverte eventer:\n$groupedDoneEvents")
         return groupedDoneEvents
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneBatchProcessor.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneBatchProcessor.kt
@@ -54,6 +54,7 @@ class DoneBatchProcessor(private val existingEntitiesInDatabase: List<Brukernoti
 
     override fun toString(): String {
         return """
+            Prosesserte ${existingEntitiesInDatabase.size} done-eventer:
             Fant ${foundBeskjed.size} done-eventer med tilhørende eventer i beskjed-tabellen.
             Fant ${foundInnboks.size} done-eventer med tilhørende eventer i innboks-tabellen.
             Fant ${foundOppgave.size} done-eventer med tilhørende eventer i oppgave-tabellen.

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneBatchProcessor.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneBatchProcessor.kt
@@ -53,8 +53,10 @@ class DoneBatchProcessor(private val existingEntitiesInDatabase: List<Brukernoti
     }
 
     override fun toString(): String {
+        val antallDoneEventer = allFoundEvents.size + notFoundEvents.size
+        val antallBrukernotifikasjoner = existingEntitiesInDatabase.size
         return """
-            Prosesserte ${existingEntitiesInDatabase.size} done-eventer:
+            Prosesserte $antallDoneEventer done-eventer, opp mot $antallBrukernotifikasjoner brukernotifikasjoner:
             Fant ${foundBeskjed.size} done-eventer med tilhørende eventer i beskjed-tabellen.
             Fant ${foundInnboks.size} done-eventer med tilhørende eventer i innboks-tabellen.
             Fant ${foundOppgave.size} done-eventer med tilhørende eventer i oppgave-tabellen.

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumerTest.kt
@@ -1,0 +1,42 @@
+package no.nav.personbruker.dittnav.eventaggregator.done
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventaggregator.common.objectmother.BrukernotifikasjonObjectMother
+import org.junit.jupiter.api.Test
+
+internal class CachedDoneEventConsumerTest {
+
+    private val doneRepo = mockk<DoneRepository>(relaxed = true)
+    private val consumer = CachedDoneEventConsumer(doneRepo)
+
+    @Test
+    fun `ved prosessering av done-eventer skal det kjores update mot databasen to ganger, en for aktive og en for inaktive`() {
+        val beskjed = BrukernotifikasjonObjectMother.giveMeBeskjed()
+        val matchingDoneEvent = DoneObjectMother.giveMeMatchingDoneEvent(beskjed)
+        val doneEventUtenMatch = DoneObjectMother.giveMeDone("utenMatch")
+
+        coEvery {
+            doneRepo.fetchAllDoneEvents()
+        } returns listOf(matchingDoneEvent, doneEventUtenMatch)
+
+        coEvery {
+            doneRepo.fetchActiveBrukernotifikasjonerFromView()
+        } returns listOf(beskjed)
+
+        coEvery {
+            doneRepo.fetchInaktiveBrukernotifikasjonerFromView()
+        } returns emptyList()
+
+        runBlocking {
+            consumer.processDoneEvents()
+        }
+
+        coVerify(exactly = 2) { doneRepo.writeDoneEventsForBeskjedToCache(any()) }
+        coVerify(exactly = 2) { doneRepo.writeDoneEventsForInnboksToCache(any()) }
+        coVerify(exactly = 2) { doneRepo.writeDoneEventsForOppgaveToCache(any()) }
+        coVerify(exactly = 2) { doneRepo.deleteDoneEventFromCache(any()) }
+    }
+}


### PR DESCRIPTION
Rettet feilen som gjorde at databasen ikke ble oppdatert etter prosessering av inaktive-eventer. Dette førte til at done-eventer som det ble funnet match for, på eventer som alt var satt til inaktive, ikke ble fjernet fra done-tabellen.

Har implementert en test som verifiserer at databasen blir oppdatert både etter prosessering av aktive og inaktive eventer.