### PR TITLE
Byttet ut "join on unnest..." med "where in any..."

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueries.kt
@@ -7,8 +7,7 @@ import java.sql.Connection
 import java.sql.ResultSet
 
 fun Connection.getBrukernotifikasjonFromViewForEventIds(eventIds: List<String>): List<Brukernotifikasjon> =
-        prepareStatement("""SELECT brukernotifikasjon_view.* FROM brukernotifikasjon_view 
-                INNER JOIN unnest(?) as params(eventId) on brukernotifikasjon_view.eventId = params.eventId""")
+        prepareStatement("""SELECT brukernotifikasjon_view.* FROM brukernotifikasjon_view WHERE eventid = ANY(?)""")
                 .use {
                     it.setArray(1, toVarcharArray(eventIds))
                     it.executeQuery().list {


### PR DESCRIPTION
Det kan se ut som det som egentlig skulle være en optimalisering (join on unnest) egentlig hadde negativ effekt på ytelse. Bytter ut med et mer rett frem "where in any"-clause