### PR TITLE
Lagt til enkel lokal rollback for håndtering av periodiske feil.

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/ThrowingEventCounterService.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/ThrowingEventCounterService.kt
@@ -1,0 +1,27 @@
+package no.nav.personbruker.dittnav.eventaggregator.common
+
+import no.nav.brukernotifikasjon.schemas.Nokkel
+import org.apache.kafka.clients.consumer.ConsumerRecords
+
+class ThrowingEventCounterService<T>(val exception: Exception? = null, val every: Int = 1) : EventBatchProcessorService<T> {
+
+    var invocationCounter = 0
+    val successfulEventsCounter get() = successfulEvents.size
+
+    val successfulEvents = mutableListOf<T>()
+
+    override suspend fun processEvents(events: ConsumerRecords<Nokkel, T>) {
+        invocationCounter += events.count()
+
+        if (exception != null && invocationCounter % every == 0) {
+            throw exception
+        } else {
+            events.map {
+                it.value()
+            }.let {
+                successfulEvents.addAll(it)
+            }
+        }
+    }
+}
+

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaTestUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaTestUtil.kt
@@ -20,6 +20,17 @@ object KafkaTestUtil {
         )
     }
 
+    fun createKafkaEmbeddedInstanceWithNumPartitions(topics: List<String>, partitions: Int): KafkaEnvironment {
+        val topicInfos = topics.map { KafkaEnvironment.TopicInfo(it, partitions = partitions) }
+
+        return KafkaEnvironment(
+                topicInfos = topicInfos,
+                withSecurity = true,
+                withSchemaRegistry = true,
+                users = listOf(JAASCredential(username, password))
+        )
+    }
+
     fun createEnvironmentForEmbeddedKafka(embeddedEnv: KafkaEnvironment): Environment {
         return Environment(
                 bootstrapServers = embeddedEnv.brokersURL.substringAfterLast("/"),

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTestIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTestIT.kt
@@ -24,12 +24,13 @@ class ConsumerTestIT {
 
     private val beskjedEvents = (1..10).map { createNokkel(it) to AvroBeskjedObjectMother.createBeskjed(it) }.toMap()
 
+    val topic = "kafkaConsumerStateTestTopic"
+
 
     @Test
     fun `Should attempt process each event exactly once if no exceptions are thrown`() {
 
-        val topic = "kafkaConsumerStateTestTopic"
-        val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(topic))
+        val embeddedEnv = KafkaTestUtil.createKafkaEmbeddedInstanceWithNumPartitions(listOf(topic), 4)
         val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
         val consumerProps = Kafka.consumerProps(testEnvironment, EventType.BESKJED, true).apply {
             put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
@@ -57,8 +58,7 @@ class ConsumerTestIT {
     @Test
     fun `Should attempt to process some events multiple times if a retriable exception was raised`() {
 
-        val topic = "kafkaConsumerStateTestTopic"
-        val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(topic))
+        val embeddedEnv = KafkaTestUtil.createKafkaEmbeddedInstanceWithNumPartitions(listOf(topic), 4)
         val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
         val consumerProps = Kafka.consumerProps(testEnvironment, EventType.BESKJED, true).apply {
             put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
@@ -86,8 +86,7 @@ class ConsumerTestIT {
     @Test
     fun `Should stop processing events if a non-retriable exception was raised`() {
 
-        val topic = "kafkaConsumerStateTestTopic"
-        val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(topic))
+        val embeddedEnv = KafkaTestUtil.createKafkaEmbeddedInstanceWithNumPartitions(listOf(topic), 4)
         val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
         val consumerProps = Kafka.consumerProps(testEnvironment, EventType.BESKJED, true).apply {
             put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTestIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTestIT.kt
@@ -1,0 +1,131 @@
+package no.nav.personbruker.dittnav.eventaggregator.common.kafka
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import no.nav.brukernotifikasjon.schemas.Beskjed
+import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.common.SimpleEventCounterService
+import no.nav.personbruker.dittnav.eventaggregator.common.ThrowingEventCounterService
+import no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util.KafkaTestUtil
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.RetriableDatabaseException
+import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UnretriableDatabaseException
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.config.Kafka
+import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be greater than`
+import org.amshove.kluent.`should contain same`
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.junit.jupiter.api.Test
+
+class ConsumerTestIT {
+
+    private val beskjedEvents = (1..10).map { createNokkel(it) to AvroBeskjedObjectMother.createBeskjed(it) }.toMap()
+
+
+    @Test
+    fun `Should attempt process each event exactly once if no exceptions are thrown`() {
+
+        val topic = "kafkaConsumerStateTestTopic"
+        val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(topic))
+        val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
+        val consumerProps = Kafka.consumerProps(testEnvironment, EventType.BESKJED, true).apply {
+            put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
+        }
+
+        embeddedEnv.start()
+
+        val eventProcessor = ThrowingEventCounterService<Beskjed>()
+        val kafkaConsumer = KafkaConsumer<Nokkel, Beskjed>(consumerProps)
+        val consumer = Consumer(topic, kafkaConsumer, eventProcessor)
+
+        runBlocking {
+
+            KafkaTestUtil.produceEvents(testEnvironment, topic, beskjedEvents)
+            pollUntilDone(consumer)
+        }
+
+        embeddedEnv.tearDown()
+
+        eventProcessor.successfulEventsCounter `should be equal to` beskjedEvents.size
+        eventProcessor.invocationCounter `should be equal to` beskjedEvents.size
+        eventProcessor.successfulEvents `should contain same` beskjedEvents.values
+    }
+
+    @Test
+    fun `Should attempt to process some events multiple times if a retriable exception was raised`() {
+
+        val topic = "kafkaConsumerStateTestTopic"
+        val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(topic))
+        val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
+        val consumerProps = Kafka.consumerProps(testEnvironment, EventType.BESKJED, true).apply {
+            put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
+        }
+
+        embeddedEnv.start()
+
+        val eventProcessor = ThrowingEventCounterService<Beskjed>(RetriableDatabaseException("Transient error"), 5)
+        val kafkaConsumer = KafkaConsumer<Nokkel, Beskjed>(consumerProps)
+        val consumer = Consumer(topic, kafkaConsumer, eventProcessor)
+
+        runBlocking {
+
+            KafkaTestUtil.produceEvents(testEnvironment, topic, beskjedEvents)
+            pollUntilDone(consumer)
+        }
+
+        embeddedEnv.tearDown()
+
+        eventProcessor.successfulEventsCounter `should be equal to` beskjedEvents.size
+        eventProcessor.invocationCounter `should be greater than` beskjedEvents.size
+        eventProcessor.successfulEvents `should contain same` beskjedEvents.values
+    }
+
+    @Test
+    fun `Should stop processing events if a non-retriable exception was raised`() {
+
+        val topic = "kafkaConsumerStateTestTopic"
+        val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(topic))
+        val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
+        val consumerProps = Kafka.consumerProps(testEnvironment, EventType.BESKJED, true).apply {
+            put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
+        }
+
+        embeddedEnv.start()
+
+        val eventProcessor = ThrowingEventCounterService<Beskjed>(UnretriableDatabaseException("Fatal error"), 5)
+        val kafkaConsumer = KafkaConsumer<Nokkel, Beskjed>(consumerProps)
+        val consumer = Consumer(topic, kafkaConsumer, eventProcessor)
+
+        runBlocking {
+
+            KafkaTestUtil.produceEvents(testEnvironment, topic, beskjedEvents)
+            pollUntilDone(consumer)
+        }
+
+        embeddedEnv.tearDown()
+
+        eventProcessor.successfulEventsCounter `should be equal to` 4
+        eventProcessor.invocationCounter `should be equal to` 5
+    }
+
+    suspend fun pollUntilDone(consumer: Consumer<Beskjed>) {
+        consumer.startPolling()
+        while (getProcessedCount(consumer) < beskjedEvents.size && consumer.job.isActive) {
+            delay(100)
+        }
+        consumer.stopPolling()
+    }
+
+    private fun getProcessedCount(consumer: Consumer<Beskjed>): Int {
+        val processor = consumer.eventBatchProcessorService
+
+        return when(processor) {
+            is SimpleEventCounterService<*> -> processor.eventCounter
+            is ThrowingEventCounterService<*> -> processor.successfulEventsCounter
+            else -> 0
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
@@ -94,9 +94,7 @@ class Consumer<T>(
 
     private suspend fun rollbackOffset() {
         withContext(Dispatchers.IO) {
-            val partition = kafkaConsumer.assignment().first()
-            val lastCommitted = kafkaConsumer.committed(partition)
-            kafkaConsumer.seek(partition, lastCommitted.offset())
+            kafkaConsumer.rollbackToLastCommitted()
         }
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
@@ -81,7 +81,6 @@ class Consumer<T>(
             stopPolling()
 
         } catch (ce: CancellationException) {
-            rollbackOffset()
             log.info("Denne coroutine-en ble stoppet. ${ce.message}", ce)
 
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
@@ -64,9 +64,11 @@ class Consumer<T>(
                 kafkaConsumer.commitSync()
             }
         } catch (rde: RetriableDatabaseException) {
+            rollbackOffset()
             log.warn("Klarte ikke å skrive til databasen, prøver igjen senrere. Topic: $topic", rde)
 
         } catch (re: RetriableException) {
+            rollbackOffset()
             log.warn("Polling mot Kafka feilet, prøver igjen senere. Topic: $topic", re)
 
         } catch (ure: UntransformableRecordException) {
@@ -79,6 +81,7 @@ class Consumer<T>(
             stopPolling()
 
         } catch (ce: CancellationException) {
+            rollbackOffset()
             log.info("Denne coroutine-en ble stoppet. ${ce.message}", ce)
 
         } catch (e: Exception) {
@@ -88,4 +91,12 @@ class Consumer<T>(
     }
 
     fun ConsumerRecords<Nokkel, T>.containsEvents() = count() > 0
+
+    private suspend fun rollbackOffset() {
+        withContext(Dispatchers.IO) {
+            val partition = kafkaConsumer.assignment().first()
+            val lastCommitted = kafkaConsumer.committed(partition)
+            kafkaConsumer.seek(partition, lastCommitted.offset())
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
@@ -1,0 +1,10 @@
+package no.nav.personbruker.dittnav.eventaggregator.common.kafka
+
+import no.nav.brukernotifikasjon.schemas.Nokkel
+import org.apache.kafka.clients.consumer.KafkaConsumer
+
+fun <T> KafkaConsumer<Nokkel, T>.rollbackToLastCommitted() {
+    val partition = assignment().first()
+    val lastCommitted = committed(partition)
+    seek(partition, lastCommitted.offset())
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
@@ -4,7 +4,8 @@ import no.nav.brukernotifikasjon.schemas.Nokkel
 import org.apache.kafka.clients.consumer.KafkaConsumer
 
 fun <T> KafkaConsumer<Nokkel, T>.rollbackToLastCommitted() {
-    val partition = assignment().first()
-    val lastCommitted = committed(partition)
-    seek(partition, lastCommitted.offset())
+    assignment().forEach { partition ->
+        val lastCommitted = committed(partition)
+        seek(partition, lastCommitted.offset())
+    }
 }


### PR DESCRIPTION
Forsøk på å løse commit problemet vi hadde ved å flytte offset tilbake til den siste "trygge" verdien vi fikk fra kafka etter det har skjedd en periodisk feil, slik at vi kan prøve å lese herfra på nytt igjen.