### PR TITLE
Fjerner logging av cachet done-event-prosessering.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/CachedDoneEventConsumer.kt
@@ -63,8 +63,6 @@ class CachedDoneEventConsumer(
             }
         }
         updateTheDatabase(groupedDoneEvents)
-        // Fjern logging etter metrikken er verifisert i Grafana
-        log.info("Status for prosessering av done-eventer, opp mot aktive eventer:\n$groupedDoneEvents")
     }
 
     private suspend fun fetchRelatedEvents(allDone: List<Done>): DoneBatchProcessor {


### PR DESCRIPTION
Dette kan nå sees i Grafana.