### PR TITLE
Gjør det enklere å starte kafka-pollerne igjen

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
@@ -50,6 +50,7 @@ class Consumer<T>(
 
     fun startPolling() {
         launch {
+            log.info("Starter en coroutine for polling på topic-en $topic.")
             kafkaConsumer.use { consumer ->
                 consumer.subscribe(listOf(topic))
 
@@ -63,7 +64,7 @@ class Consumer<T>(
     private suspend fun processBatchOfEvents() = withContext(Dispatchers.IO) {
         try {
             val records = kafkaConsumer.poll(Duration.of(100, ChronoUnit.MILLIS))
-            if(records.containsEvents()) {
+            if (records.containsEvents()) {
                 eventBatchProcessorService.processEvents(records)
                 kafkaConsumer.commitSync()
             }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/pollingApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/pollingApi.kt
@@ -25,7 +25,8 @@ fun Routing.pollingApi(appContext: ApplicationContext) {
 
 }
 
-private fun restartPolling(appContext: ApplicationContext) {
+private suspend fun restartPolling(appContext: ApplicationContext) {
+    KafkaConsumerSetup.stopAllKafkaConsumers(appContext)
     appContext.reinitiateConsumers()
     KafkaConsumerSetup.startAllKafkaPollers(appContext)
     appContext.cachedDoneEventConsumer.poll()


### PR DESCRIPTION
**Sørger for at alle kafka-pollere kjører etter at start-polling har blitt kalt.**
Tidligere kunne man risikere at de poller-ene som fortsatt kjørte, i det start-polling ble kalt, ville stoppe mens de som tidligere var stoppet ville starte. Slik ble tilstanden stadig flippet, med mindre man manuelt kalte stop-polling. Legger derfor heller til en eksplisitt stop-polling før alle kafka-pollere blir startet på nytt.

**Logger at det startes en ny coroutine for å prosessere en gitt topic.**
Dette skal typisk bare skje hvis pollingen har blitt stoppet, og vi manuelt starter det igjen. Det er også en fin måte å følge med på om det spinnes opp flere coroutiner enn tiltenkt for dette.