### PR TITLE
Funksjonalitet for å telle unike eventer, duplikater og totalt antall eventer på en topic

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/eventCountingApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/eventCountingApi.kt
@@ -11,6 +11,16 @@ import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.KafkaEventCount
 fun Routing.eventCountingApi(kafkaEventCounterService: KafkaEventCounterService, cacheEventCounterService: CacheEventCounterService) {
 
     get("/internal/count/all") {
+        val kafkaEvents = kafkaEventCounterService.countUniqueEvents()
+        val cachedEvents = cacheEventCounterService.countAllEvents()
+        val responseText = """
+            $kafkaEvents
+            $cachedEvents
+        """.trimIndent()
+        call.respondText(text = responseText, contentType = ContentType.Text.Plain)
+    }
+
+    get("/internal/count/all-legacy") {
         val kafkaEvents = kafkaEventCounterService.countAllEvents()
         val cachedEvents = cacheEventCounterService.countAllEvents()
         val responseText = """

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/KafkaEventCounterService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/KafkaEventCounterService.kt
@@ -1,13 +1,12 @@
 package no.nav.personbruker.dittnav.eventaggregator.metrics.kafka
 
-import no.nav.brukernotifikasjon.schemas.Beskjed
-import no.nav.brukernotifikasjon.schemas.Done
-import no.nav.brukernotifikasjon.schemas.Innboks
-import no.nav.brukernotifikasjon.schemas.Oppgave
+import no.nav.brukernotifikasjon.schemas.*
 import no.nav.personbruker.dittnav.eventaggregator.config.Environment
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.config.Kafka
 import no.nav.personbruker.dittnav.eventaggregator.config.isOtherEnvironmentThanProd
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.slf4j.LoggerFactory
 
 class KafkaEventCounterService(val environment: Environment) {
@@ -69,6 +68,67 @@ class KafkaEventCounterService(val environment: Environment) {
         } catch (e: Exception) {
             log.warn("Klarte ikke å telle antall done-eventer", e)
             -1
+        }
+    }
+
+    fun countUniqueEvents(): NumberOfUniqueKafkaRecords {
+        val beskjedPair = countUniqueBeskjeder()
+        val innboksPair = countUniqueInnboksEventer()
+        val oppgaverPair = countUniqueOppgaver()
+        val donePair = countUniqueDoneEvents()
+        val result = NumberOfUniqueKafkaRecords(
+                beskjed = beskjedPair.first,
+                beskjedDuplicates = beskjedPair.second,
+                innboks = innboksPair.first,
+                innboksDuplicates = innboksPair.second,
+                oppgaver = oppgaverPair.first,
+                oppgaverDuplicates = oppgaverPair.second,
+                done = donePair.first,
+                doneDuplicates = donePair.second
+        )
+
+        log.info("Fant følgende unike eventer:\n$result")
+        return result
+    }
+
+    fun countUniqueBeskjeder(): Pair<Long, Long> {
+        return try {
+            countUniqueEvents(beskjedConsumer as KafkaConsumer<Nokkel, GenericRecord>, EventType.BESKJED)
+        } catch (e: Exception) {
+            log.warn("Klarte ikke å telle antall beskjed-eventer", e)
+            Pair(-1, -1)
+        }
+    }
+
+    fun countUniqueInnboksEventer(): Pair<Long, Long> {
+        return if (isOtherEnvironmentThanProd()) {
+            try {
+                countUniqueEvents(innboksConsumer as KafkaConsumer<Nokkel, GenericRecord>, EventType.INNBOKS)
+            } catch (e: Exception) {
+                log.warn("Klarte ikke å telle antall innboks-eventer", e)
+                Pair(-1L, -1L)
+            }
+        } else {
+            Pair(0L, 0L)
+        }
+    }
+
+    fun countUniqueOppgaver(): Pair<Long, Long> {
+        return try {
+            countUniqueEvents(oppgaveConsumer as KafkaConsumer<Nokkel, GenericRecord>, EventType.OPPGAVE)
+        } catch (e: Exception) {
+            log.warn("Klarte ikke å telle antall oppgave-eventer", e)
+            Pair(-1, -1)
+        }
+    }
+
+    fun countUniqueDoneEvents(): Pair<Long, Long> {
+        return try {
+            countUniqueEvents(doneConsumer as KafkaConsumer<Nokkel, GenericRecord>, EventType.DONE)
+
+        } catch (e: Exception) {
+            log.warn("Klarte ikke å telle antall done-eventer", e)
+            Pair(-1, -1)
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/NumberOfUniqueKafkaRecords.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/NumberOfUniqueKafkaRecords.kt
@@ -1,0 +1,33 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.kafka
+
+data class NumberOfUniqueKafkaRecords(
+        val beskjed: Long = 0,
+        val beskjedDuplicates: Long = 0,
+        val innboks: Long = 0,
+        val innboksDuplicates: Long = 0,
+        val oppgaver: Long = 0,
+        val oppgaverDuplicates: Long = 0,
+        val done: Long = 0,
+        val doneDuplicates: Long = 0
+) {
+
+    val totalt = beskjed + innboks + oppgaver + done
+    val totaltDuplicates = beskjedDuplicates + innboksDuplicates + oppgaverDuplicates + doneDuplicates
+    val beskjedTotal = beskjed + beskjedDuplicates
+    val innboksTotal = innboks + innboksDuplicates
+    val oppgaveTotal = oppgaver + oppgaverDuplicates
+    val doneTotal = done + doneDuplicates
+    val eventsInTotal = beskjedTotal + innboksTotal + oppgaveTotal + doneTotal
+
+    override fun toString(): String {
+        return """
+            Kafka       Unique      Duplicates              "På topic"
+            Beskjed     $beskjed    $beskjedDuplicates      $beskjedTotal
+            Innboks     $innboks    $innboksDuplicates      $innboksTotal
+            Oppgave     $oppgaver   $oppgaverDuplicates     $oppgaveTotal
+            Done        $done       $doneDuplicates         $doneTotal
+            Totalt      $totalt     $totaltDuplicates       $eventsInTotal
+        """.trimIndent()
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/UniqueKafkaEventIdentifier.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/UniqueKafkaEventIdentifier.kt
@@ -1,0 +1,3 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.kafka
+
+data class UniqueKafkaEventIdentifier(val eventId: String, val systembruker: String, val fodselsnummer: String)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingApi.kt
@@ -15,6 +15,11 @@ fun Routing.kafkaCountingApi(kafkaEventCounterService: KafkaEventCounterService,
         call.respondText(text = numberOfEvents.toString(), contentType = ContentType.Text.Plain)
     }
 
+    get("/internal/kafka/count/unique") {
+        val numberOfEvents = kafkaEventCounterService.countUniqueEvents()
+        call.respondText(text = numberOfEvents.toString(), contentType = ContentType.Text.Plain)
+    }
+
     get("/internal/kafka/count/beskjed") {
         var kafkaTopicParameter: String? = call.request.queryParameters["topic"]
         val responseText = countEventsOfType(kafkaTopicParameter, EventType.BESKJED, kafkaEventCounterService, kafkaTopicEventCounterService)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingUtil.kt
@@ -60,11 +60,11 @@ fun countUniqueEvents(consumer: KafkaConsumer<Nokkel, GenericRecord>, eventType:
     return Pair(numberOfUniqueEvents, duplicationCounter)
 }
 
-private fun countBatch(records: ConsumerRecords<Nokkel, GenericRecord>, uniqueConstraints: HashSet<UniqueKafkaEventIdentifier>): Int {
+private fun countBatch(records: ConsumerRecords<Nokkel, GenericRecord>, uniqueEvents: HashSet<UniqueKafkaEventIdentifier>): Int {
     var duplicateCounter = 0
     records.forEach { record ->
         val event = transformToInternal(record)
-        val wasNewUniqueEvent = uniqueConstraints.add(event)
+        val wasNewUniqueEvent = uniqueEvents.add(event)
         if (!wasNewUniqueEvent) {
             duplicateCounter++
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingUtil.kt
@@ -5,6 +5,8 @@ import no.nav.personbruker.dittnav.eventaggregator.common.kafka.resetTheGroupIds
 import no.nav.personbruker.dittnav.eventaggregator.config.Environment
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.config.Kafka
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.KafkaException
@@ -23,7 +25,7 @@ fun <T> createCountConsumer(eventType: EventType, topic: String, environment: En
     return consumer
 }
 
- fun <T> countEvents(consumer: KafkaConsumer<Nokkel, T>, eventType: EventType): Long {
+fun <T> countEvents(consumer: KafkaConsumer<Nokkel, T>, eventType: EventType): Long {
     val start = Instant.now()
     var counter: Long = 0
     var records = consumer.poll(Duration.of(5000, ChronoUnit.MILLIS))
@@ -37,6 +39,46 @@ fun <T> createCountConsumer(eventType: EventType, topic: String, environment: En
     logTimeUsed(start, counter, eventType)
     consumer.resetTheGroupIdsOffsetToZero()
     return counter
+}
+
+fun countUniqueEvents(consumer: KafkaConsumer<Nokkel, GenericRecord>, eventType: EventType): Pair<Long, Long> {
+    val start = Instant.now()
+    var records = consumer.poll(Duration.of(5000, ChronoUnit.MILLIS))
+    var duplicationCounter: Long = 0
+    val uniqueEvents = HashSet<UniqueKafkaEventIdentifier>(25000000)
+
+    duplicationCounter += countBatch(records, uniqueEvents)
+
+    while (records.foundRecords()) {
+        records = consumer.poll(Duration.of(500, ChronoUnit.MILLIS))
+        duplicationCounter += countBatch(records, uniqueEvents)
+    }
+
+    val numberOfUniqueEvents = uniqueEvents.size.toLong()
+    logTimeUsed(start, numberOfUniqueEvents, duplicationCounter, eventType)
+    consumer.resetTheGroupIdsOffsetToZero()
+    return Pair(numberOfUniqueEvents, duplicationCounter)
+}
+
+private fun countBatch(records: ConsumerRecords<Nokkel, GenericRecord>, uniqueConstraints: HashSet<UniqueKafkaEventIdentifier>): Int {
+    var duplicateCounter = 0
+    records.forEach { record ->
+        val event = transformToInternal(record)
+        val wasNewUniqueEvent = uniqueConstraints.add(event)
+        if (!wasNewUniqueEvent) {
+            duplicateCounter++
+        }
+    }
+    return duplicateCounter
+}
+
+private fun transformToInternal(record: ConsumerRecord<Nokkel, GenericRecord>): UniqueKafkaEventIdentifier {
+    val key = record.key()
+    return UniqueKafkaEventIdentifier(
+            key.getEventId(),
+            key.getSystembruker(),
+            record.value().get("fodselsnummer") as String
+    )
 }
 
 fun <T> closeConsumer(consumer: KafkaConsumer<Nokkel, T>) {
@@ -55,7 +97,7 @@ fun <T> closeConsumer(consumer: KafkaConsumer<Nokkel, T>) {
 }
 
 fun getDefaultTopicName(eventType: EventType): String {
-    return when(eventType) {
+    return when (eventType) {
         EventType.BESKJED -> Kafka.beskjedTopicName
         EventType.OPPGAVE -> Kafka.oppgaveTopicName
         EventType.INNBOKS -> Kafka.innboksTopicName
@@ -71,4 +113,10 @@ private fun logTimeUsed(start: Instant, counter: Long, eventType: EventType) {
     val end = Instant.now()
     val time = end.toEpochMilli() - start.toEpochMilli()
     log.info("Fant $counter $eventType-eventer, det tok ${time}ms")
+}
+
+private fun logTimeUsed(start: Instant, counter: Long, uniqueEvents: Long, eventType: EventType) {
+    val end = Instant.now()
+    val time = end.toEpochMilli() - start.toEpochMilli()
+    log.info("Fant $counter unike $eventType-eventer, og $uniqueEvents duplikater, det tok ${time}ms")
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/NumberOfUniqueKafkaRecordsTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/NumberOfUniqueKafkaRecordsTest.kt
@@ -1,0 +1,19 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.kafka
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class NumberOfUniqueKafkaRecordsTest {
+
+    @Test
+    fun `Skal summere riktig`() {
+        val kafkaRecords = NumberOfUniqueKafkaRecords(1, 2, 3, 4, 5, 6, 7, 8)
+        kafkaRecords.totalt `should be equal to` 1 + 3 + 5 + 7
+        kafkaRecords.beskjedTotal `should be equal to` 1 + 2
+        kafkaRecords.innboksTotal `should be equal to` 3 + 4
+        kafkaRecords.oppgaveTotal `should be equal to` 5 + 6
+        kafkaRecords.doneTotal `should be equal to` 7 + 8
+        kafkaRecords.eventsInTotal `should be equal to` 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8
+    }
+
+}


### PR DESCRIPTION
På sikt kan denne koden erstatte den gamle tellekoden, men nå i første omgang legger jeg det bare til som et tillegg.
Ytelsen mellom den gamle og den nye implementasjonen ser veldig lik ut, men vil gjerne teste det i et miljø først.