### PR TITLE
PB-451. Del 2 - Rapportering av metrikker for eventer i cache-en

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbEventCounterServiceTestIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbEventCounterServiceTestIT.kt
@@ -1,0 +1,184 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.Beskjed
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.createBeskjeder
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.deleteAllBeskjed
+import no.nav.personbruker.dittnav.eventaggregator.common.database.H2Database
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.done.Done
+import no.nav.personbruker.dittnav.eventaggregator.done.DoneObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.done.createDoneEvents
+import no.nav.personbruker.dittnav.eventaggregator.done.deleteAllDone
+import no.nav.personbruker.dittnav.eventaggregator.innboks.Innboks
+import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.innboks.createInnboksEventer
+import no.nav.personbruker.dittnav.eventaggregator.innboks.deleteAllInnboks
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.Oppgave
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.createOppgaver
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.deleteAllOppgave
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+internal class DbEventCounterServiceTestIT {
+
+    private val database = H2Database()
+    private val repository = MetricsRepository(database)
+
+    @AfterEach
+    fun cleanUp() {
+        runBlocking {
+            database.dbQuery {
+                deleteAllBeskjed()
+                deleteAllInnboks()
+                deleteAllOppgave()
+                deleteAllDone()
+            }
+        }
+    }
+
+    @Test
+    fun `Should count beskjed events`() {
+        val beskjeder = createBeskjedEventer()
+        val metricsProbe = mockk<DbCountingMetricsProbe>(relaxed = true)
+        val metricsSession = initMetricsSession(metricsProbe, EventType.BESKJED)
+        val service = DbEventCounterService(metricsProbe, repository)
+
+        runBlocking {
+            service.countEventsAndReportMetrics()
+        }
+
+        metricsSession.getTotalNumber() `should be equal to` 2
+        metricsSession.getProducers().size `should be equal to` 2
+        metricsSession.getNumberOfEventsFor(beskjeder[0].systembruker) `should be equal to` 1
+        metricsSession.getNumberOfEventsFor(beskjeder[1].systembruker) `should be equal to` 1
+    }
+
+
+    @Test
+    fun `Should count innboks events`() {
+        val innboksEventer = createInnboksEventer()
+        val metricsProbe = mockk<DbCountingMetricsProbe>(relaxed = true)
+        val metricsSession = initMetricsSession(metricsProbe, EventType.INNBOKS)
+        val service = DbEventCounterService(metricsProbe, repository)
+
+        runBlocking {
+            service.countEventsAndReportMetrics()
+        }
+
+        metricsSession.getTotalNumber() `should be equal to` 2
+        metricsSession.getProducers().size `should be equal to` 2
+        metricsSession.getNumberOfEventsFor(innboksEventer[0].systembruker) `should be equal to` 1
+        metricsSession.getNumberOfEventsFor(innboksEventer[1].systembruker) `should be equal to` 1
+    }
+
+    @Test
+    fun `Should count oppgave events`() {
+        val oppgaver = createOppgaveEventer()
+        val metricsProbe = mockk<DbCountingMetricsProbe>(relaxed = true)
+        val metricsSession = initMetricsSession(metricsProbe, EventType.OPPGAVE)
+        val service = DbEventCounterService(metricsProbe, repository)
+
+        runBlocking {
+            service.countEventsAndReportMetrics()
+        }
+
+        metricsSession.getTotalNumber() `should be equal to` 2
+        metricsSession.getProducers().size `should be equal to` 2
+        metricsSession.getNumberOfEventsFor(oppgaver[0].systembruker) `should be equal to` 1
+        metricsSession.getNumberOfEventsFor(oppgaver[1].systembruker) `should be equal to` 1
+    }
+
+    @Test
+    fun `Should count done events from the wait table, and include brukernotifikasjoner marked as inactive (done)`() {
+        createBeskjedEventer()
+        createInnboksEventer()
+        createOppgaveEventer()
+        val doneEventer = createDoneEventInWaitingTable()
+
+        val metricsProbe = mockk<DbCountingMetricsProbe>(relaxed = true)
+        val metricsSession = initMetricsSession(metricsProbe, EventType.DONE)
+        val service = DbEventCounterService(metricsProbe, repository)
+
+        runBlocking {
+            service.countEventsAndReportMetrics()
+        }
+
+        metricsSession.getTotalNumber() `should be equal to` 4
+        metricsSession.getProducers().size `should be equal to` 2
+        metricsSession.getNumberOfEventsFor("dummySystembruker") `should be equal to` 3
+        metricsSession.getNumberOfEventsFor(doneEventer[0].systembruker) `should be equal to` 1
+    }
+
+    private fun initMetricsSession(metricsProbe: DbCountingMetricsProbe, eventType: EventType): DbCountingMetricsSession {
+        val metricsSession = DbCountingMetricsSession(eventType)
+        `Sorg for at metrics session trigges`(metricsProbe, metricsSession, eventType)
+        return metricsSession
+    }
+
+    private fun `Sorg for at metrics session trigges`(metricsProbe: DbCountingMetricsProbe, metricsSession: DbCountingMetricsSession, eventType: EventType) {
+        val slot = slot<suspend DbCountingMetricsSession.() -> Unit>()
+        coEvery { metricsProbe.runWithMetrics(eventType, capture(slot)) } coAnswers {
+            slot.captured.invoke(metricsSession)
+        }
+    }
+
+    private fun createBeskjedEventer(): List<Beskjed> {
+        val beskjeder = listOf(
+                BeskjedObjectMother.giveMeAktivBeskjed("321", "567", "systembrukerB"),
+                BeskjedObjectMother.giveMeInaktivBeskjed()
+        )
+
+        runBlocking {
+            database.dbQuery {
+                createBeskjeder(beskjeder)
+            }
+        }
+        return beskjeder
+    }
+
+    private fun createInnboksEventer(): List<Innboks> {
+        val innboksEventer = listOf(
+                InnboksObjectMother.giveMeAktivInnboks("213", "678", "systembrukerI"),
+                InnboksObjectMother.giveMeInaktivInnboks()
+        )
+        runBlocking {
+            database.dbQuery {
+                createInnboksEventer(innboksEventer)
+            }
+        }
+        return innboksEventer
+    }
+
+    private fun createOppgaveEventer(): List<Oppgave> {
+        val oppgaver = listOf(
+                OppgaveObjectMother.giveMeAktivOppgave("132", "789", "systembrukerO"),
+                OppgaveObjectMother.giveMeInaktivOppgave()
+        )
+        runBlocking {
+            database.dbQuery {
+                createOppgaver(oppgaver)
+            }
+        }
+        return oppgaver
+    }
+
+    private fun createDoneEventInWaitingTable(): List<Done> {
+        val doneEventer = listOf(
+                DoneObjectMother.giveMeDone("e-2", "systembrukerD")
+        )
+        runBlocking {
+            database.dbQuery {
+                createDoneEvents(doneEventer)
+            }
+        }
+        return doneEventer
+    }
+
+}

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/metricsQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/metricsQueriesTest.kt
@@ -1,0 +1,124 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.*
+import no.nav.personbruker.dittnav.eventaggregator.common.database.H2Database
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+
+internal class metricsQueriesTest {
+
+    private val database = H2Database()
+
+    private val beskjed1: Beskjed
+    private val beskjed2: Beskjed
+    private val beskjed3: Beskjed
+    private val beskjed4: Beskjed
+
+    private val allEventsForSingleSystembruker: List<Beskjed>
+
+    init {
+        beskjed1 = createBeskjed(BeskjedObjectMother.giveMeAktivBeskjed("1", "12345"))
+        beskjed2 = createBeskjed(BeskjedObjectMother.giveMeAktivBeskjed("2", "12345"))
+        beskjed3 = createBeskjed(BeskjedObjectMother.giveMeAktivBeskjed("3", "12345"))
+        beskjed4 = createBeskjed(BeskjedObjectMother.giveMeAktivBeskjed("4", "6789"))
+        allEventsForSingleSystembruker = listOf(beskjed1, beskjed2, beskjed3, beskjed4)
+    }
+
+    private fun createBeskjed(beskjed: Beskjed): Beskjed {
+        return runBlocking {
+            database.dbQuery {
+                createBeskjed(beskjed).entityId.let {
+                    beskjed.copy(id = it)
+                }
+            }
+        }
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runBlocking {
+            database.dbQuery { deleteAllBeskjed() }
+        }
+    }
+
+    @Test
+    fun `Skal telle det totale antall beskjeder`() {
+        runBlocking {
+            database.dbQuery {
+                countTotalNumberOfEvents(EventType.BESKJED)
+            }
+        } `should be equal to` allEventsForSingleSystembruker.size.toLong()
+    }
+
+    @Test
+    fun `Skal telle det totale antall aktive beskjeder`() {
+        runBlocking {
+            database.dbQuery {
+                countTotalNumberOfEventsByActiveStatus(EventType.BESKJED, true)
+            }
+        } `should be equal to` allEventsForSingleSystembruker.size.toLong()
+    }
+
+    @Test
+    fun `Skal telle det totale antall inaktive beskjeder`() {
+        runBlocking {
+            database.dbQuery {
+                countTotalNumberOfEventsByActiveStatus(EventType.BESKJED, false)
+            }
+        } `should be equal to` 0
+    }
+
+    @Test
+    fun `Skal hente totalantallet eventer per produsent`() {
+        val beskjedFraAnnenSystembruker = createBeskjed(BeskjedObjectMother.giveMeAktivBeskjed("5", "123", "enAnnenSystembruker"))
+
+        val eventerPerSystembruker =
+                runBlocking {
+                    database.dbQuery {
+                        countTotalNumberOfEventsGroupedBySystembruker(EventType.BESKJED)
+                    }
+                }
+
+        eventerPerSystembruker.size `should be equal to` 2
+        eventerPerSystembruker[beskjed1.systembruker]?.`should be equal to`(allEventsForSingleSystembruker.size)
+        eventerPerSystembruker[beskjedFraAnnenSystembruker.systembruker]?.`should be equal to`(1)
+    }
+
+    @Test
+    fun `Skal hente totalantallet brukernotifikasjoner per produsent basert paa status`() {
+        val inaktivBeskjed = createBeskjed(BeskjedObjectMother.giveMeInaktivBeskjed())
+
+        val aktiveBrukernotifikasjonerPerProdusent =
+                runBlocking {
+                    database.dbQuery {
+                        countTotalNumberOfBrukernotifikasjonerByActiveStatus(true)
+                    }
+                }
+
+        val inaktiveBrukernotifikasjonerPerProdusent =
+                runBlocking {
+                    database.dbQuery {
+                        countTotalNumberOfBrukernotifikasjonerByActiveStatus(false)
+                    }
+                }
+
+        aktiveBrukernotifikasjonerPerProdusent.size `should be equal to` 1
+        aktiveBrukernotifikasjonerPerProdusent[beskjed1.systembruker]?.`should be equal to`(allEventsForSingleSystembruker.size)
+        inaktiveBrukernotifikasjonerPerProdusent.size `should be equal to` 1
+        inaktiveBrukernotifikasjonerPerProdusent[inaktivBeskjed.systembruker]?.`should be equal to`(1)
+
+        `delete beskjed with eventId`(inaktivBeskjed.eventId)
+    }
+
+    private fun `delete beskjed with eventId`(eventId: String) {
+        runBlocking {
+            database.dbQuery {
+                deleteBeskjedWithEventId(eventId)
+            }
+        }
+    }
+
+}

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterServiceIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterServiceIT.kt
@@ -1,4 +1,4 @@
-package no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topics
+package no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topic
 
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -7,9 +7,6 @@ import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util.KafkaTestUtil
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
-import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topic.TopicEventCounterService
-import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topic.TopicMetricsProbe
-import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topic.TopicMetricsSession
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldEqualTo

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedRepository.kt
@@ -3,10 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.beskjed
 import no.nav.personbruker.dittnav.eventaggregator.common.database.BrukernotifikasjonRepository
 import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.common.database.util.countTotalNumberOfEvents
-import no.nav.personbruker.dittnav.eventaggregator.common.database.util.countTotalNumberOfEventsByActiveStatus
 import no.nav.personbruker.dittnav.eventaggregator.common.database.util.persistEachIndividuallyAndAggregateResults
-import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -25,24 +22,6 @@ class BeskjedRepository(private val database: Database) : BrukernotifikasjonRepo
             entities.persistEachIndividuallyAndAggregateResults { entity ->
                 createBeskjed(entity)
             }
-        }
-    }
-
-    override suspend fun getTotalNumberOfEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEvents(EventType.BESKJED)
-        }
-    }
-
-    override suspend fun getNumberOfActiveEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEventsByActiveStatus(EventType.BESKJED, true)
-        }
-    }
-
-    override suspend fun getNumberOfInactiveEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEventsByActiveStatus(EventType.BESKJED, false)
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/BrukernotifikasjonRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/BrukernotifikasjonRepository.kt
@@ -6,8 +6,4 @@ interface BrukernotifikasjonRepository<T> {
 
     suspend fun createOneByOneToFilterOutTheProblematicEvents(entities: List<T>): ListPersistActionResult<T>
 
-    suspend fun getTotalNumberOfEvents(): Long
-    suspend fun getNumberOfActiveEvents(): Long
-    suspend fun getNumberOfInactiveEvents(): Long
-
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
@@ -11,9 +11,12 @@ import no.nav.personbruker.dittnav.eventaggregator.health.HealthService
 import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksEventService
 import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksRepository
 import no.nav.personbruker.dittnav.eventaggregator.metrics.buildDBMetricsProbe
+import no.nav.personbruker.dittnav.eventaggregator.metrics.buildDbEventCountingMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.metrics.buildEventMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.metrics.buildTopicMetricsProbe
-import no.nav.personbruker.dittnav.eventaggregator.metrics.db.CacheEventCounterService
+import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.CacheEventCounterService
+import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.DbEventCounterService
+import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.MetricsRepository
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.KafkaEventCounterService
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.KafkaTopicEventCounterService
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topic.TopicEventCounterService
@@ -60,7 +63,11 @@ class ApplicationContext {
 
     val kafkaEventCounterService = KafkaEventCounterService(environment)
     val kafkaTopicEventCounterService = KafkaTopicEventCounterService(environment)
-    val cacheEventCounterService = CacheEventCounterService(environment, beskjedRepository, innboksRepository, oppgaveRepository, doneRepository)
+
+    val metricsRepository = MetricsRepository(database)
+    val cacheEventCounterService = CacheEventCounterService(environment, metricsRepository)
+    val dbEventCountingMetricsProbe = buildDbEventCountingMetricsProbe(environment, database)
+    val dbEventCounterService = DbEventCounterService(dbEventCountingMetricsProbe, metricsRepository)
 
     val topicMetricsProbe = buildTopicMetricsProbe(environment, database)
     val topicEventCounterService = TopicEventCounterService(environment, topicMetricsProbe)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
@@ -10,7 +10,8 @@ import io.prometheus.client.hotspot.DefaultExports
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventaggregator.done.waitTableApi
 import no.nav.personbruker.dittnav.eventaggregator.health.healthApi
-import no.nav.personbruker.dittnav.eventaggregator.metrics.db.cacheCountingApi
+import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.cacheCountingApi
+import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.dbCountingApi
 import no.nav.personbruker.dittnav.eventaggregator.metrics.eventCountingApi
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.kafkaCountingApi
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.pollingApi
@@ -27,6 +28,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
         pollingApi(appContext)
         waitTableApi(appContext)
         topicCountingApi(appContext.topicEventCounterService)
+        dbCountingApi(appContext.dbEventCounterService)
     }
 
     configureStartupHook(appContext)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepository.kt
@@ -4,8 +4,6 @@ import no.nav.personbruker.dittnav.eventaggregator.beskjed.setBeskjederAktivflag
 import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.common.database.entity.Brukernotifikasjon
 import no.nav.personbruker.dittnav.eventaggregator.common.database.entity.getBrukernotifikasjonFromViewForEventIds
-import no.nav.personbruker.dittnav.eventaggregator.common.database.util.countTotalNumberOfEvents
-import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.innboks.setInnboksEventerAktivFlag
 import no.nav.personbruker.dittnav.eventaggregator.oppgave.setOppgaverAktivFlag
 
@@ -74,12 +72,6 @@ class DoneRepository(private val database: Database) {
     suspend fun deleteDoneEventsFromCache(doneEventsToDelete: List<Done>) {
         database.queryWithExceptionTranslation {
             deleteDoneEvents(doneEventsToDelete)
-        }
-    }
-
-    suspend fun getTotalNumberOfEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEvents(EventType.DONE)
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksRepository.kt
@@ -3,10 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.innboks
 import no.nav.personbruker.dittnav.eventaggregator.common.database.BrukernotifikasjonRepository
 import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.common.database.util.countTotalNumberOfEvents
-import no.nav.personbruker.dittnav.eventaggregator.common.database.util.countTotalNumberOfEventsByActiveStatus
 import no.nav.personbruker.dittnav.eventaggregator.common.database.util.persistEachIndividuallyAndAggregateResults
-import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import org.slf4j.LoggerFactory
 
 class InnboksRepository(private val database: Database) : BrukernotifikasjonRepository<Innboks> {
@@ -26,24 +23,6 @@ class InnboksRepository(private val database: Database) : BrukernotifikasjonRepo
             }
         }
 
-    }
-
-    override suspend fun getTotalNumberOfEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEvents(EventType.INNBOKS)
-        }
-    }
-
-    override suspend fun getNumberOfActiveEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEventsByActiveStatus(EventType.INNBOKS, true)
-        }
-    }
-
-    override suspend fun getNumberOfInactiveEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEventsByActiveStatus(EventType.INNBOKS, false)
-        }
     }
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/PrometheusMetricsCollector.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/PrometheusMetricsCollector.kt
@@ -6,17 +6,18 @@ import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 
 object PrometheusMetricsCollector {
 
-    val NAMESPACE = "dittnav_consumer"
+    const val NAMESPACE = "dittnav_consumer"
 
-    val EVENTS_SEEN_NAME = "kafka_events_seen"
-    val EVENTS_PROCESSED_NAME = "kafka_events_processed"
-    val EVENTS_FAILED_NAME = "kafka_events_failed"
-    val EVENTS_DUPLICATE_KEY_NAME = "kafka_events_duplicate_key"
-    val EVENT_LAST_SEEN_NAME = "kafka_event_type_last_seen"
-    val DB_CACHED_EVENTS = "db_cached_events"
-    val KAFKA_TOPIC_TOTAL_EVENTS = "kafka_topic_total_events"
-    val KAFKA_TOPIC_UNIQUE_EVENTS = "kafka_topic_unique_events"
-    val KAFKA_TOPIC_DUPLICATED_EVENTS = "kafka_topic_duplicated_events"
+    const val EVENTS_SEEN_NAME = "kafka_events_seen"
+    const val EVENTS_PROCESSED_NAME = "kafka_events_processed"
+    const val EVENTS_FAILED_NAME = "kafka_events_failed"
+    const val EVENTS_DUPLICATE_KEY_NAME = "kafka_events_duplicate_key"
+    const val EVENT_LAST_SEEN_NAME = "kafka_event_type_last_seen"
+    const val KAFKA_TOPIC_TOTAL_EVENTS = "kafka_topic_total_events"
+    const val KAFKA_TOPIC_UNIQUE_EVENTS = "kafka_topic_unique_events"
+    const val KAFKA_TOPIC_DUPLICATED_EVENTS = "kafka_topic_duplicated_events"
+    const val DB_CACHED_EVENTS = "db_cached_events"
+    const val DB_TOTAL_EVENTS = "db_total_events"
 
     private val MESSAGES_SEEN: Counter = Counter.build()
             .name(EVENTS_SEEN_NAME)
@@ -81,6 +82,13 @@ object PrometheusMetricsCollector {
             .labelNames("type", "producer")
             .register()
 
+    private val CACHED_EVENTS_IN_TOTAL: Gauge = Gauge.build()
+            .name(DB_TOTAL_EVENTS)
+            .namespace(NAMESPACE)
+            .help("Total number of events of type in the cache")
+            .labelNames("type", "producer")
+            .register()
+
     fun registerEventsSeen(count: Int, eventType: String, producer: String) {
         MESSAGES_SEEN.labels(eventType, producer).inc(count.toDouble())
         MESSAGE_LAST_SEEN.labels(eventType, producer).setToCurrentTime()
@@ -112,6 +120,10 @@ object PrometheusMetricsCollector {
 
     fun registerTotalNumberOfEvents(count: Int, eventType: EventType, producer: String) {
         MESSAGES_TOTAL.labels(eventType.eventType, producer).set(count.toDouble())
+    }
+
+    fun registerTotalNumberOfEventsInCache(count: Int, eventType: EventType, producer: String) {
+        CACHED_EVENTS_IN_TOTAL.labels(eventType.eventType, producer).set(count.toDouble())
     }
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/CacheEventCounterService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/CacheEventCounterService.kt
@@ -1,32 +1,23 @@
-package no.nav.personbruker.dittnav.eventaggregator.metrics.db
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
 
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedRepository
 import no.nav.personbruker.dittnav.eventaggregator.config.Environment
 import no.nav.personbruker.dittnav.eventaggregator.config.isOtherEnvironmentThanProd
-import no.nav.personbruker.dittnav.eventaggregator.done.DoneRepository
-import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksRepository
-import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveRepository
 import org.slf4j.LoggerFactory
 
-class CacheEventCounterService(val environment: Environment,
-                               val beskjedRepository: BeskjedRepository,
-                               val innboksRepository: InnboksRepository,
-                               val oppgaveRepository: OppgaveRepository,
-                               val doneRepository: DoneRepository
-) {
+class CacheEventCounterService(val environment: Environment, val repository: MetricsRepository) {
 
     private val log = LoggerFactory.getLogger(CacheEventCounterService::class.java)
 
     suspend fun countAllEvents(): NumberOfCachedRecords {
         return try {
             val result = NumberOfCachedRecords(
-                    beskjedRepository.getNumberOfActiveEvents(),
-                    beskjedRepository.getNumberOfInactiveEvents(),
-                    innboksRepository.getNumberOfActiveEvents(),
-                    innboksRepository.getNumberOfInactiveEvents(),
-                    oppgaveRepository.getNumberOfActiveEvents(),
-                    oppgaveRepository.getNumberOfInactiveEvents(),
-                    doneRepository.getTotalNumberOfEvents()
+                    repository.getNumberOfActiveBeskjedEvents(),
+                    repository.getNumberOfInactiveBeskjedEvents(),
+                    repository.getNumberOfActiveInnboksEvents(),
+                    repository.getNumberOfInactiveInnboksEvents(),
+                    repository.getNumberOfActiveOppgaveEvents(),
+                    repository.getNumberOfInactiveOppgaveEvents(),
+                    repository.getTotalNumberOfDoneEvents()
             )
             log.info("Fant følgende eventer:\n$result")
             result
@@ -39,7 +30,7 @@ class CacheEventCounterService(val environment: Environment,
 
     suspend fun countBeskjeder(): Long {
         return try {
-            beskjedRepository.getTotalNumberOfEvents()
+            repository.getTotalNumberOfBeskjedEvents()
 
         } catch (e: Exception) {
             log.warn("Klarte ikke å telle antall beskjed-eventer", e)
@@ -50,7 +41,7 @@ class CacheEventCounterService(val environment: Environment,
     suspend fun countInnboksEventer(): Long {
         return if (isOtherEnvironmentThanProd()) {
             try {
-                innboksRepository.getTotalNumberOfEvents()
+                repository.getTotalNumberOfInnboksEvents()
 
             } catch (e: Exception) {
                 log.warn("Klarte ikke å telle antall innboks-eventer", e)
@@ -63,7 +54,7 @@ class CacheEventCounterService(val environment: Environment,
 
     suspend fun countOppgaver(): Long {
         return try {
-            oppgaveRepository.getTotalNumberOfEvents()
+            repository.getTotalNumberOfOppgaveEvents()
 
         } catch (e: Exception) {
             log.warn("Klarte ikke å telle antall oppgave-eventer", e)
@@ -73,7 +64,7 @@ class CacheEventCounterService(val environment: Environment,
 
     suspend fun countDoneEvents(): Long {
         return try {
-            doneRepository.getTotalNumberOfEvents()
+            repository.getTotalNumberOfDoneEvents()
 
         } catch (e: Exception) {
             log.warn("Klarte ikke å telle antall done-eventer", e)
@@ -83,10 +74,10 @@ class CacheEventCounterService(val environment: Environment,
 
     suspend fun countAllDoneEvents(): Long {
         return try {
-            val doneEventsInWaitingTable = doneRepository.getTotalNumberOfEvents()
-            val inactiveBeskjeder = beskjedRepository.getNumberOfInactiveEvents()
-            val inactiveInnbokseventer = innboksRepository.getNumberOfInactiveEvents()
-            val inactiveOppgave = oppgaveRepository.getNumberOfInactiveEvents()
+            val doneEventsInWaitingTable = repository.getTotalNumberOfDoneEvents()
+            val inactiveBeskjeder = repository.getNumberOfInactiveBeskjedEvents()
+            val inactiveInnbokseventer = repository.getNumberOfInactiveInnboksEvents()
+            val inactiveOppgave = repository.getNumberOfInactiveOppgaveEvents()
             val totalNumberOfDoneEvents = doneEventsInWaitingTable + inactiveBeskjeder + inactiveInnbokseventer + inactiveOppgave
 
             totalNumberOfDoneEvents

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsProbe.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsProbe.kt
@@ -1,0 +1,44 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.metrics.MetricsReporter
+import no.nav.personbruker.dittnav.eventaggregator.metrics.ProducerNameScrubber
+import no.nav.personbruker.dittnav.eventaggregator.metrics.PrometheusMetricsCollector
+import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE
+import org.slf4j.LoggerFactory
+
+class DbCountingMetricsProbe(private val metricsReporter: MetricsReporter,
+                             private val nameScrubber: ProducerNameScrubber) {
+
+    private val log = LoggerFactory.getLogger(DbCountingMetricsProbe::class.java)
+
+    suspend fun runWithMetrics(eventType: EventType, block: suspend DbCountingMetricsSession.() -> Unit) {
+        val session = DbCountingMetricsSession(eventType)
+        block.invoke(session)
+
+        if (session.getProducers().isNotEmpty()) {
+            handleTotalEventsByProducer(session)
+        }
+    }
+
+    private suspend fun handleTotalEventsByProducer(session: DbCountingMetricsSession) {
+        session.getProducers().forEach { producerName ->
+            val numberOfEvents = session.getNumberOfEventsFor(producerName)
+            val eventTypeName = session.eventType.toString()
+            val printableAlias = nameScrubber.getPublicAlias(producerName)
+
+            reportEvents(numberOfEvents, eventTypeName, printableAlias, DB_TOTAL_EVENTS_IN_CACHE)
+            PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(numberOfEvents, session.eventType, printableAlias)
+        }
+    }
+
+    private suspend fun reportEvents(count: Int, eventType: String, producerAlias: String, metricName: String) {
+        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, producerAlias))
+    }
+
+    private fun counterField(events: Int): Map<String, Int> = listOf("counter" to events).toMap()
+
+    private fun createTagMap(eventType: String, producer: String): Map<String, String> =
+            listOf("eventType" to eventType, "producer" to producer).toMap()
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSession.kt
@@ -1,0 +1,31 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+
+class DbCountingMetricsSession(val eventType: EventType) {
+
+    private val cachedEventsByProducer = HashMap<String, Int>(50)
+
+    fun addEventsByProducent(eventerPerProducer: Map<String, Int>) {
+        eventerPerProducer.forEach { produsent ->
+            cachedEventsByProducer[produsent.key] = cachedEventsByProducer.getOrDefault(produsent.key, 0).plus(produsent.value)
+        }
+    }
+
+    fun getProducers(): Set<String> {
+        return cachedEventsByProducer.keys
+    }
+
+    fun getNumberOfEventsFor(producer: String): Int {
+        return cachedEventsByProducer.getOrDefault(producer, 0)
+    }
+
+    fun getTotalNumber(): Int {
+        var total = 0
+        cachedEventsByProducer.forEach { producer ->
+            total += producer.value
+        }
+        return total
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSession.kt
@@ -6,9 +6,9 @@ class DbCountingMetricsSession(val eventType: EventType) {
 
     private val cachedEventsByProducer = HashMap<String, Int>(50)
 
-    fun addEventsByProducent(eventerPerProducer: Map<String, Int>) {
-        eventerPerProducer.forEach { produsent ->
-            cachedEventsByProducer[produsent.key] = cachedEventsByProducer.getOrDefault(produsent.key, 0).plus(produsent.value)
+    fun addEventsByProducer(eventsByProducer: Map<String, Int>) {
+        eventsByProducer.forEach { producer ->
+            cachedEventsByProducer[producer.key] = cachedEventsByProducer.getOrDefault(producer.key, 0).plus(producer.value)
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSession.kt
@@ -28,4 +28,11 @@ class DbCountingMetricsSession(val eventType: EventType) {
         return total
     }
 
+    override fun toString(): String {
+        return """DbCountingMetricsSession(
+|                   eventType=$eventType, 
+|                   cachedEventsByProducer=$cachedEventsByProducer
+|                 )""".trimMargin()
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbEventCounterService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbEventCounterService.kt
@@ -1,0 +1,85 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.config.isOtherEnvironmentThanProd
+import org.slf4j.LoggerFactory
+
+class DbEventCounterService(private val metricsProbe: DbCountingMetricsProbe,
+                            private val repository: MetricsRepository) {
+
+    private val log = LoggerFactory.getLogger(DbEventCounterService::class.java)
+
+    suspend fun countEventsAndReportMetrics() = withContext(Dispatchers.IO) {
+        val beskjeder = async {
+            countAndReportMetricsForBeskjeder()
+        }
+        val innboks = async {
+            countAndReportMetricsForInnboksEventer()
+        }
+        val oppgave = async {
+            countAndReportMetricsForOppgaver()
+        }
+        val done = async {
+            countAndReportMetricsForDoneEvents()
+        }
+
+        beskjeder.await()
+        innboks.await()
+        oppgave.await()
+        done.await()
+    }
+
+    private suspend fun countAndReportMetricsForBeskjeder() {
+        try {
+            metricsProbe.runWithMetrics(EventType.BESKJED) {
+                val grupperPerProdusent = repository.getNumberOfBeskjedEventsGroupedByProdusent()
+                addEventsByProducent(grupperPerProdusent)
+            }
+
+        } catch (e: Exception) {
+            log.warn("Klarte ikke å telle og rapportere metrics for antall beskjed-eventer i cache-en", e)
+        }
+    }
+
+    private suspend fun countAndReportMetricsForInnboksEventer() {
+        if (isOtherEnvironmentThanProd()) {
+            try {
+                metricsProbe.runWithMetrics(EventType.INNBOKS) {
+                    val grupperPerProdusent = repository.getNumberOfInnboksEventsGroupedByProdusent()
+                    addEventsByProducent(grupperPerProdusent)
+                }
+
+            } catch (e: Exception) {
+                log.warn("Klarte ikke å telle og rapportere metrics for antall innboks-eventer i cache-en", e)
+            }
+        }
+    }
+
+    private suspend fun countAndReportMetricsForOppgaver() {
+        try {
+            metricsProbe.runWithMetrics(EventType.OPPGAVE) {
+                val grupperPerProdusent = repository.getNumberOfOppgaveEventsGroupedByProdusent()
+                addEventsByProducent(grupperPerProdusent)
+            }
+
+        } catch (e: Exception) {
+            log.warn("Klarte ikke å telle og rapportere metrics for antall oppgave-eventer i cache-en", e)
+        }
+    }
+
+    private suspend fun countAndReportMetricsForDoneEvents() {
+        try {
+            metricsProbe.runWithMetrics(EventType.DONE) {
+                addEventsByProducent(repository.getNumberOfDoneEventsInWaitingTableGroupedByProdusent())
+                addEventsByProducent(repository.getNumberOfInactiveBrukernotifikasjonerGroupedByProdusent())
+            }
+
+        } catch (e: Exception) {
+            log.warn("Klarte ikke å telle og rapportere metrics for antall done-eventer i cache-en", e)
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbEventCounterService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbEventCounterService.kt
@@ -36,7 +36,7 @@ class DbEventCounterService(private val metricsProbe: DbCountingMetricsProbe,
         try {
             metricsProbe.runWithMetrics(EventType.BESKJED) {
                 val grupperPerProdusent = repository.getNumberOfBeskjedEventsGroupedByProdusent()
-                addEventsByProducent(grupperPerProdusent)
+                addEventsByProducer(grupperPerProdusent)
             }
 
         } catch (e: Exception) {
@@ -49,7 +49,7 @@ class DbEventCounterService(private val metricsProbe: DbCountingMetricsProbe,
             try {
                 metricsProbe.runWithMetrics(EventType.INNBOKS) {
                     val grupperPerProdusent = repository.getNumberOfInnboksEventsGroupedByProdusent()
-                    addEventsByProducent(grupperPerProdusent)
+                    addEventsByProducer(grupperPerProdusent)
                 }
 
             } catch (e: Exception) {
@@ -62,7 +62,7 @@ class DbEventCounterService(private val metricsProbe: DbCountingMetricsProbe,
         try {
             metricsProbe.runWithMetrics(EventType.OPPGAVE) {
                 val grupperPerProdusent = repository.getNumberOfOppgaveEventsGroupedByProdusent()
-                addEventsByProducent(grupperPerProdusent)
+                addEventsByProducer(grupperPerProdusent)
             }
 
         } catch (e: Exception) {
@@ -73,8 +73,8 @@ class DbEventCounterService(private val metricsProbe: DbCountingMetricsProbe,
     private suspend fun countAndReportMetricsForDoneEvents() {
         try {
             metricsProbe.runWithMetrics(EventType.DONE) {
-                addEventsByProducent(repository.getNumberOfDoneEventsInWaitingTableGroupedByProdusent())
-                addEventsByProducent(repository.getNumberOfInactiveBrukernotifikasjonerGroupedByProdusent())
+                addEventsByProducer(repository.getNumberOfDoneEventsInWaitingTableGroupedByProdusent())
+                addEventsByProducer(repository.getNumberOfInactiveBrukernotifikasjonerGroupedByProdusent())
             }
 
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/MetricsRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/MetricsRepository.kt
@@ -1,0 +1,102 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class MetricsRepository(private val database: Database) {
+
+    private val log: Logger = LoggerFactory.getLogger(MetricsRepository::class.java)
+
+    suspend fun getNumberOfActiveBeskjedEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsByActiveStatus(EventType.BESKJED, true)
+        }
+    }
+
+    suspend fun getNumberOfInactiveBeskjedEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsByActiveStatus(EventType.BESKJED, false)
+        }
+    }
+
+    suspend fun getTotalNumberOfBeskjedEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEvents(EventType.BESKJED)
+        }
+    }
+
+    suspend fun getNumberOfBeskjedEventsGroupedByProdusent(): Map<String, Int> {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsGroupedBySystembruker(EventType.BESKJED)
+        }
+    }
+
+    suspend fun getNumberOfActiveInnboksEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsByActiveStatus(EventType.INNBOKS, true)
+        }
+    }
+
+    suspend fun getNumberOfInactiveInnboksEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsByActiveStatus(EventType.INNBOKS, false)
+        }
+    }
+
+    suspend fun getTotalNumberOfInnboksEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEvents(EventType.INNBOKS)
+        }
+    }
+
+    suspend fun getNumberOfInnboksEventsGroupedByProdusent(): Map<String, Int> {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsGroupedBySystembruker(EventType.INNBOKS)
+        }
+    }
+
+    suspend fun getNumberOfActiveOppgaveEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsByActiveStatus(EventType.OPPGAVE, true)
+        }
+    }
+
+    suspend fun getNumberOfInactiveOppgaveEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsByActiveStatus(EventType.OPPGAVE, false)
+        }
+    }
+
+    suspend fun getTotalNumberOfOppgaveEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEvents(EventType.OPPGAVE)
+        }
+    }
+
+    suspend fun getTotalNumberOfDoneEvents(): Long {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEvents(EventType.DONE)
+        }
+    }
+
+    suspend fun getNumberOfOppgaveEventsGroupedByProdusent(): Map<String, Int> {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsGroupedBySystembruker(EventType.OPPGAVE)
+        }
+    }
+
+    suspend fun getNumberOfDoneEventsInWaitingTableGroupedByProdusent(): Map<String, Int> {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfEventsGroupedBySystembruker(EventType.DONE)
+        }
+    }
+
+    suspend fun getNumberOfInactiveBrukernotifikasjonerGroupedByProdusent(): Map<String, Int> {
+        return database.queryWithExceptionTranslation {
+            countTotalNumberOfBrukernotifikasjonerByActiveStatus(false)
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/NumberOfCachedRecords.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/NumberOfCachedRecords.kt
@@ -1,4 +1,4 @@
-package no.nav.personbruker.dittnav.eventaggregator.metrics.db
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
 
 data class NumberOfCachedRecords(val beskjedAktive: Long = 0,
                                  val beskjedInaktive: Long = 0,

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/cacheCountingApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/cacheCountingApi.kt
@@ -1,4 +1,4 @@
-package no.nav.personbruker.dittnav.eventaggregator.metrics.db
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
 
 import io.ktor.application.call
 import io.ktor.http.ContentType

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/dbCountingApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/dbCountingApi.kt
@@ -1,0 +1,16 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import io.ktor.application.call
+import io.ktor.http.ContentType
+import io.ktor.response.respondText
+import io.ktor.routing.Routing
+import io.ktor.routing.get
+
+fun Routing.dbCountingApi(topicEventCounterService: DbEventCounterService) {
+
+    get("/internal/metrics/report/db") {
+        topicEventCounterService.countEventsAndReportMetrics()
+        call.respondText(text = "Metrics for cache-en har blitt rapportert", contentType = ContentType.Text.Plain)
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/metricsQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/metricsQueries.kt
@@ -1,0 +1,60 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import java.sql.Connection
+import java.sql.ResultSet
+
+const val countResultColumnIndex = 1
+
+fun Connection.countTotalNumberOfEvents(eventType: EventType): Long {
+    return prepareStatement("SELECT COUNT(*) FROM $eventType",
+            ResultSet.TYPE_SCROLL_INSENSITIVE,
+            ResultSet.CONCUR_READ_ONLY)
+            .use { statement ->
+                val resultSet = statement.executeQuery()
+                resultSet.last()
+                resultSet.getLong(countResultColumnIndex)
+            }
+}
+
+fun Connection.countTotalNumberOfEventsByActiveStatus(eventType: EventType, aktiv: Boolean): Long {
+    return prepareStatement("SELECT COUNT(*) FROM $eventType WHERE aktiv = ?",
+            ResultSet.TYPE_SCROLL_INSENSITIVE,
+            ResultSet.CONCUR_READ_ONLY)
+            .use { statement ->
+                statement.setBoolean(1, aktiv)
+                val resultSet = statement.executeQuery()
+                resultSet.last()
+                resultSet.getLong(countResultColumnIndex)
+            }
+}
+
+fun Connection.countTotalNumberOfBrukernotifikasjonerByActiveStatus(aktiv: Boolean): Map<String, Int> {
+    return prepareStatement(
+            "SELECT systembruker, COUNT(*) FROM brukernotifikasjon_view WHERE aktiv = ? GROUP BY systembruker;",
+            ResultSet.TYPE_SCROLL_INSENSITIVE,
+            ResultSet.CONCUR_READ_ONLY)
+            .use { statement ->
+                statement.setBoolean(1, aktiv)
+                val resultSet = statement.executeQuery()
+                mutableMapOf<String, Int>().apply {
+                    while (resultSet.next()) {
+                        put(resultSet.getString(1), resultSet.getInt(2))
+                    }
+                }
+            }
+}
+
+fun Connection.countTotalNumberOfEventsGroupedBySystembruker(eventType: EventType): Map<String, Int> {
+    return prepareStatement("SELECT systembruker, COUNT(*) FROM $eventType GROUP BY systembruker",
+            ResultSet.TYPE_SCROLL_INSENSITIVE,
+            ResultSet.CONCUR_READ_ONLY)
+            .use { statement ->
+                val resultSet = statement.executeQuery()
+                mutableMapOf<String, Int>().apply {
+                    while (resultSet.next()) {
+                        put(resultSet.getString(1), resultSet.getInt(2))
+                    }
+                }
+            }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/eventCountingApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/eventCountingApi.kt
@@ -5,7 +5,7 @@ import io.ktor.http.ContentType
 import io.ktor.response.respondText
 import io.ktor.routing.Routing
 import io.ktor.routing.get
-import no.nav.personbruker.dittnav.eventaggregator.metrics.db.CacheEventCounterService
+import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.CacheEventCounterService
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.KafkaEventCounterService
 
 fun Routing.eventCountingApi(kafkaEventCounterService: KafkaEventCounterService, cacheEventCounterService: CacheEventCounterService) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/topicCountingApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/topicCountingApi.kt
@@ -10,7 +10,7 @@ fun Routing.topicCountingApi(topicEventCounterService: TopicEventCounterService)
 
     get("/internal/metrics/report/topic") {
         topicEventCounterService.countEventsAndReportMetrics()
-        call.respondText(text = "Metrics har blitt rapporter", contentType = ContentType.Text.Plain)
+        call.respondText(text = "Metrics har blitt rapportert", contentType = ContentType.Text.Plain)
     }
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricsProbeSetup.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricsProbeSetup.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.metrics
 import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.config.Environment
 import no.nav.personbruker.dittnav.eventaggregator.metrics.db.DBMetricsProbe
+import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.DbCountingMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.InfluxMetricsReporter
 import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.SensuClient
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topic.TopicMetricsProbe
@@ -26,6 +27,13 @@ fun buildTopicMetricsProbe(environment: Environment, database: Database): TopicM
     val nameResolver = ProducerNameResolver(database)
     val nameScrubber = ProducerNameScrubber(nameResolver)
     return TopicMetricsProbe(metricsReporter, nameScrubber)
+}
+
+fun buildDbEventCountingMetricsProbe(environment: Environment, database: Database): DbCountingMetricsProbe {
+    val metricsReporter = resolveMetricsReporter(environment)
+    val nameResolver = ProducerNameResolver(database)
+    val nameScrubber = ProducerNameScrubber(nameResolver)
+    return DbCountingMetricsProbe(metricsReporter, nameScrubber)
 }
 
 private fun resolveMetricsReporter(environment: Environment): MetricsReporter {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveRepository.kt
@@ -3,10 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.oppgave
 import no.nav.personbruker.dittnav.eventaggregator.common.database.BrukernotifikasjonRepository
 import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.common.database.util.countTotalNumberOfEvents
-import no.nav.personbruker.dittnav.eventaggregator.common.database.util.countTotalNumberOfEventsByActiveStatus
 import no.nav.personbruker.dittnav.eventaggregator.common.database.util.persistEachIndividuallyAndAggregateResults
-import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import org.slf4j.LoggerFactory
 
 class OppgaveRepository(private val database: Database) : BrukernotifikasjonRepository<Oppgave> {
@@ -24,24 +21,6 @@ class OppgaveRepository(private val database: Database) : BrukernotifikasjonRepo
             entities.persistEachIndividuallyAndAggregateResults { entity ->
                 createOppgave(entity)
             }
-        }
-    }
-
-    override suspend fun getTotalNumberOfEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEvents(EventType.OPPGAVE)
-        }
-    }
-
-    override suspend fun getNumberOfActiveEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEventsByActiveStatus(EventType.OPPGAVE, true)
-        }
-    }
-
-    override suspend fun getNumberOfInactiveEvents(): Long {
-        return database.queryWithExceptionTranslation {
-            countTotalNumberOfEventsByActiveStatus(EventType.OPPGAVE, false)
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
@@ -24,7 +24,7 @@ object BeskjedObjectMother {
 
     fun giveMeAktivBeskjed(eventId: String, fodselsnummer: String, systembruker: String): Beskjed {
         return Beskjed(
-                uid = Random.nextInt(1,100).toString(),
+                uid = Random.nextInt(1, 100).toString(),
                 systembruker = systembruker,
                 eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC")),
                 synligFremTil = LocalDateTime.now(ZoneId.of("UTC")),

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneObjectMother.kt
@@ -12,6 +12,11 @@ object DoneObjectMother {
         return giveMeDone(eventId, systembruker, fodselsnummer)
     }
 
+    fun giveMeDone(eventId: String, systembruker: String): Done {
+        val fodselsnummer = "12345"
+        return giveMeDone(eventId, systembruker, fodselsnummer)
+    }
+
     fun giveMeDone(eventId: String, systembruker: String, fodselsnummer: String): Done {
         return Done(
                 systembruker,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/DBMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/DBMetricsProbeTest.kt
@@ -67,6 +67,6 @@ class DBMetricsProbeTest {
                 listOf("eventType" to EventType.DONE.toString(), "producer" to "test-user").toMap()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsCached(2, EventType.DONE, "test-user") }
 
-        assertEquals(capturedFieldsForCachedEvents.captured["counter"] as Int, 2)
+        assertEquals(2, capturedFieldsForCachedEvents.captured["counter"])
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/EventMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/EventMetricsProbeTest.kt
@@ -110,8 +110,8 @@ internal class EventMetricsProbeTest {
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsProcessed(2, any(), any()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsFailed(1, any(), any()) }
 
-        assertEquals(capturedFieldsForSeen.captured["counter"] as Int, 3)
-        assertEquals(capturedFieldsForProcessed.captured["counter"] as Int, 2)
-        assertEquals(capturedFieldsForFailed.captured["counter"] as Int, 1)
+        assertEquals(3, capturedFieldsForSeen.captured["counter"])
+        assertEquals(2, capturedFieldsForProcessed.captured["counter"])
+        assertEquals(1, capturedFieldsForFailed.captured["counter"])
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/NumberOfCachedRecordsTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/NumberOfCachedRecordsTest.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.metrics.db
 
+import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.NumberOfCachedRecords
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsProbeTest.kt
@@ -1,0 +1,82 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.metrics.MetricsReporter
+import no.nav.personbruker.dittnav.eventaggregator.metrics.ProducerNameResolver
+import no.nav.personbruker.dittnav.eventaggregator.metrics.ProducerNameScrubber
+import no.nav.personbruker.dittnav.eventaggregator.metrics.PrometheusMetricsCollector
+import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class DbCountingMetricsProbeTest {
+
+    private val metricsReporter = mockk<MetricsReporter>()
+    private val prometheusCollector = mockkObject(PrometheusMetricsCollector)
+    private val producerNameResolver = mockk<ProducerNameResolver>()
+
+    @BeforeEach
+    fun cleanup() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `Should report correct number of events`() {
+        val dummyCountResultFromDb = mutableMapOf<String, Int>().apply {
+            put("produsent1", 1)
+            put("produsent2", 2)
+        }
+
+        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
+        val nameScrubber = ProducerNameScrubber(producerNameResolver)
+        val topicMetricsProbe = DbCountingMetricsProbe(metricsReporter, nameScrubber)
+
+        val capturedTotalEventsInCache = slot<Map<String, Any>>()
+
+        coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE, capture(capturedTotalEventsInCache), any()) } returns Unit
+
+        runBlocking {
+            topicMetricsProbe.runWithMetrics(EventType.BESKJED) {
+                addEventsByProducer(dummyCountResultFromDb)
+            }
+        }
+
+        coVerify(exactly = 2) { metricsReporter.registerDataPoint(any(), any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(1, any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(2, any(), any()) }
+
+        kotlin.test.assertEquals(1, capturedTotalEventsInCache.captured["counter"])
+    }
+
+    @Test
+    fun `Should replace system name with alias`() {
+        val producerName = "sys-t-user"
+        val producerAlias = "test-user"
+
+        coEvery { producerNameResolver.getProducerNameAlias(producerName) } returns producerAlias
+        val nameScrubber = ProducerNameScrubber(producerNameResolver)
+        val metricsProbe = DbCountingMetricsProbe(metricsReporter, nameScrubber)
+
+        val producerNameForPrometheus = slot<String>()
+        val capturedTagsForTotal = slot<Map<String, String>>()
+
+        coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE, any(), capture(capturedTagsForTotal)) } returns Unit
+        every { PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(any(), any(), capture(producerNameForPrometheus)) } returns Unit
+
+        runBlocking {
+            metricsProbe.runWithMetrics(EventType.BESKJED) {
+                addEventsByProducer(mapOf(Pair(producerName, 2)))
+            }
+        }
+
+        coVerify(exactly = 1) { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE, any(), any()) }
+
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(any(), any(), any()) }
+
+        kotlin.test.assertEquals(producerAlias, producerNameForPrometheus.captured)
+        kotlin.test.assertEquals(producerAlias, capturedTagsForTotal.captured["producer"])
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSessionTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSessionTest.kt
@@ -25,7 +25,7 @@ internal class DbCountingMetricsSessionTest {
     @Test
     fun `Skal telle opp riktig totalantall eventer, og rapportere riktig per produsent`() {
         val session = DbCountingMetricsSession(EventType.BESKJED)
-        session.addEventsByProducent(beskjederGruppertPerProdusent)
+        session.addEventsByProducer(beskjederGruppertPerProdusent)
 
         session.getTotalNumber() `should be equal to` (produsent1Antall + produsent2Antall + produsent3Antall)
 
@@ -40,8 +40,8 @@ internal class DbCountingMetricsSessionTest {
     @Test
     fun `Skal telle opp riktig totalantall eventer, hvis eventer legges til flere ganger`() {
         val session = DbCountingMetricsSession(EventType.BESKJED)
-        session.addEventsByProducent(beskjederGruppertPerProdusent)
-        session.addEventsByProducent(beskjederGruppertPerProdusent)
+        session.addEventsByProducer(beskjederGruppertPerProdusent)
+        session.addEventsByProducer(beskjederGruppertPerProdusent)
 
         session.getTotalNumber() `should be equal to` (produsent1Antall + produsent2Antall + produsent3Antall) * 2
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSessionTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/DbCountingMetricsSessionTest.kt
@@ -1,0 +1,56 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
+
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldContainAll
+import org.junit.jupiter.api.Test
+
+internal class DbCountingMetricsSessionTest {
+
+    val beskjederGruppertPerProdusent = mutableMapOf<String, Int>()
+    val produsent1 = "produsent1"
+    val produsent2 = "produsent2"
+    val produsent3 = "produsent3"
+    val produsent1Antall = 1
+    val produsent2Antall = 2
+    val produsent3Antall = 3
+    val alleProdusenter = listOf(produsent1, produsent2, produsent3)
+
+    init {
+        beskjederGruppertPerProdusent[produsent1] = produsent1Antall
+        beskjederGruppertPerProdusent[produsent2] = produsent2Antall
+        beskjederGruppertPerProdusent[produsent3] = produsent3Antall
+    }
+
+    @Test
+    fun `Skal telle opp riktig totalantall eventer, og rapportere riktig per produsent`() {
+        val session = DbCountingMetricsSession(EventType.BESKJED)
+        session.addEventsByProducent(beskjederGruppertPerProdusent)
+
+        session.getTotalNumber() `should be equal to` (produsent1Antall + produsent2Antall + produsent3Antall)
+
+        session.getProducers().size `should be equal to` alleProdusenter.size
+        session.getProducers() shouldContainAll alleProdusenter
+
+        session.getNumberOfEventsFor(produsent1) `should be equal to` produsent1Antall
+        session.getNumberOfEventsFor(produsent2) `should be equal to` produsent2Antall
+        session.getNumberOfEventsFor(produsent3) `should be equal to` produsent3Antall
+    }
+
+    @Test
+    fun `Skal telle opp riktig totalantall eventer, hvis eventer legges til flere ganger`() {
+        val session = DbCountingMetricsSession(EventType.BESKJED)
+        session.addEventsByProducent(beskjederGruppertPerProdusent)
+        session.addEventsByProducent(beskjederGruppertPerProdusent)
+
+        session.getTotalNumber() `should be equal to` (produsent1Antall + produsent2Antall + produsent3Antall) * 2
+
+        session.getProducers().size `should be equal to` alleProdusenter.size
+        session.getProducers() shouldContainAll alleProdusenter
+
+        session.getNumberOfEventsFor(produsent1) `should be equal to` produsent1Antall * 2
+        session.getNumberOfEventsFor(produsent2) `should be equal to` produsent2Antall * 2
+        session.getNumberOfEventsFor(produsent3) `should be equal to` produsent3Antall * 2
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/NumberOfCachedRecordsTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/db/count/NumberOfCachedRecordsTest.kt
@@ -1,6 +1,5 @@
-package no.nav.personbruker.dittnav.eventaggregator.metrics.db
+package no.nav.personbruker.dittnav.eventaggregator.metrics.db.count
 
-import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.NumberOfCachedRecords
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicMetricsProbeTest.kt
@@ -54,9 +54,9 @@ internal class TopicMetricsProbeTest {
         verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEvents(4, any(), any()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerDuplicatedEventsOnTopic(1, any(), any()) }
 
-        assertEquals(capturedFieldsForUnique.captured["counter"] as Int, 3)
-        assertEquals(capturedFieldsForTotalEvents.captured["counter"] as Int, 4)
-        assertEquals(capturedFieldsForDuplicated.captured["counter"] as Int, 1)
+        assertEquals(3, capturedFieldsForUnique.captured["counter"])
+        assertEquals(4, capturedFieldsForTotalEvents.captured["counter"])
+        assertEquals(1, capturedFieldsForDuplicated.captured["counter"])
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicMetricsSessionTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicMetricsSessionTest.kt
@@ -51,6 +51,8 @@ internal class TopicMetricsSessionTest {
         metricsSession.getNumberOfUniqueEvents(produsent1) `should be equal to` 1
         metricsSession.getNumberOfUniqueEvents(produsent2) `should be equal to` 2
         metricsSession.getNumberOfUniqueEvents(produsent3) `should be equal to` 3
+
+        metricsSession.getProducersWithEvents().size `should be equal to` 3
     }
 
 }


### PR DESCRIPTION
Implementert telling av antall eventer i cache-en gruppert på produsent.

Rapportering av metrikken kan foreløpig trigges fra `../internal/metrics/report/db`.

Del 3 av denne oppgaven kommer til å gjøre slik at alle metrikkene i denne oppgaven blir kjørt periodisk.

PB-451. Sette opp metrics for eventer i databasen vs kafka