### PR TITLE
Aktiverer scraping av applikasjonens Prometheus-metrikker

### DIFF
--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -15,6 +15,7 @@ spec:
     path: /internal/isReady
     initialDelay: 5
   prometheus:
+    enabled: true
     path: /metrics
   replicas:
     min: 1


### PR DESCRIPTION
PB-451. Sette opp metrics for eventer i databasen vs kafka