### PR TITLE
Gjenbruker kafkaklientene som brukes for telling av eventer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,6 @@ tasks {
         environment("SERVICEUSER_USERNAME", "username")
         environment("SERVICEUSER_PASSWORD", "password")
         environment("GROUP_ID", "dittnav_events")
-        environment("COUNTER_GROUP_ID", "dittnav_event_counter001")
         environment("DB_HOST", "localhost:5432")
         environment("DB_NAME", "dittnav-event-cache-preprod")
         environment("DB_PASSWORD", "testpassword")

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaTestUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaTestUtil.kt
@@ -38,7 +38,6 @@ object KafkaTestUtil {
                 username = username,
                 password = password,
                 groupId = "groupId-for-tests",
-                counterGroupId = "counterGroupId-for-tests",
                 dbAdmin = "dbAdminIkkeIBrukHer",
                 dbHost = "dbHostIkkeIBrukHer",
                 dbMountPath = "dbMountPathIkkeIBrukHer",

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.kafka
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 
 fun <T> KafkaConsumer<Nokkel, T>.rollbackToLastCommitted() {
@@ -14,4 +15,8 @@ fun <T> KafkaConsumer<Nokkel, T>.resetTheGroupIdsOffsetToZero() {
     assignment().forEach { partition ->
         seek(partition, 0)
     }
+}
+
+fun <T> ConsumerRecords<Nokkel, T>.foundRecords(): Boolean {
+    return !isEmpty
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Environment.kt
@@ -5,7 +5,6 @@ data class Environment(val bootstrapServers: String = getEnvVar("KAFKA_BOOTSTRAP
                        val username: String = getEnvVar("SERVICEUSER_USERNAME"),
                        val password: String = getEnvVar("SERVICEUSER_PASSWORD"),
                        val groupId: String = getEnvVar("GROUP_ID"),
-                       val counterGroupId: String = getEnvVar("COUNTER_GROUP_ID"),
                        val dbHost: String = getEnvVar("DB_HOST"),
                        val dbName: String = getEnvVar("DB_NAME"),
                        val dbAdmin: String = getEnvVar("DB_NAME") + "-admin",

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Kafka.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Kafka.kt
@@ -48,7 +48,7 @@ object Kafka {
     }
 
     fun counterConsumerProps(env: Environment, eventTypeToConsume: EventType, enableSecurity: Boolean = isCurrentlyRunningOnNais()): Properties {
-        val groupIdAndEventType = env.counterGroupId + eventTypeToConsume.eventType
+        val groupIdAndEventType = "dn-aggregator_metrics_counter_" + eventTypeToConsume.eventType
         return Properties().apply {
             put(ConsumerConfig.GROUP_ID_CONFIG, groupIdAndEventType)
             put(ConsumerConfig.CLIENT_ID_CONFIG, groupIdAndEventType + getHostname(InetSocketAddress(0)))

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/KafkaConsumerSetup.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/KafkaConsumerSetup.kt
@@ -53,4 +53,16 @@ object KafkaConsumerSetup {
         val kafkaConsumer = KafkaConsumer<Nokkel, Done>(kafkaProps)
         return Consumer(Kafka.doneTopicName, kafkaConsumer, eventProcessor)
     }
+
+    fun <T> createCountConsumer(eventType: EventType,
+                                topic: String,
+                                environment: Environment,
+                                enableSecurity: Boolean = ConfigUtil.isCurrentlyRunningOnNais()): KafkaConsumer<Nokkel, T> {
+
+        val kafkaProps = Kafka.counterConsumerProps(environment, eventType, enableSecurity)
+        val consumer = KafkaConsumer<Nokkel, T>(kafkaProps)
+        consumer.subscribe(listOf(topic))
+        return consumer
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
@@ -51,5 +51,6 @@ private fun Application.configureShutdownHook(appContext: ApplicationContext) {
         }
         appContext.database.dataSource.close()
         appContext.kafkaEventCounterService.closeAllConsumers()
+        appContext.topicEventCounterService.closeAllConsumers()
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingUtil.kt
@@ -1,12 +1,12 @@
 package no.nav.personbruker.dittnav.eventaggregator.metrics.kafka
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.foundRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.resetTheGroupIdsOffsetToZero
 import no.nav.personbruker.dittnav.eventaggregator.config.Environment
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.config.Kafka
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topic.UniqueKafkaEventIdentifierTransformer
-import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topic.foundRecords
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterService.kt
@@ -4,8 +4,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.foundRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.resetTheGroupIdsOffsetToZero
-import no.nav.personbruker.dittnav.eventaggregator.config.*
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.config.isOtherEnvironmentThanProd
+import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.closeConsumer
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -13,7 +16,11 @@ import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
-class TopicEventCounterService(val environment: Environment, val topicMetricsProbe: TopicMetricsProbe) {
+class TopicEventCounterService(val topicMetricsProbe: TopicMetricsProbe,
+                               val beskjedCountConsumer: KafkaConsumer<Nokkel, GenericRecord>,
+                               val oppgaveCountConsumer: KafkaConsumer<Nokkel, GenericRecord>,
+                               val innboksCountConsumer: KafkaConsumer<Nokkel, GenericRecord>,
+                               val doneCountConsumer: KafkaConsumer<Nokkel, GenericRecord>) {
 
     private val log = LoggerFactory.getLogger(TopicEventCounterService::class.java)
 
@@ -37,21 +44,19 @@ class TopicEventCounterService(val environment: Environment, val topicMetricsPro
         done.await()
     }
 
-    private suspend fun countAndReportMetricsForBeskjeder() {
-        val beskjedConsumer = createCountConsumer<GenericRecord>(EventType.BESKJED, Kafka.beskjedTopicName, environment)
+    suspend fun countAndReportMetricsForBeskjeder() {
         try {
-            countEventsAndReportMetrics(beskjedConsumer, EventType.BESKJED)
+            countEventsAndReportMetrics(beskjedCountConsumer, EventType.BESKJED)
 
         } catch (e: Exception) {
             log.warn("Klarte ikke å telle og rapportere metrics for antall beskjed-eventer", e)
         }
     }
 
-    private suspend fun countAndReportMetricsForInnboksEventer() {
+    suspend fun countAndReportMetricsForInnboksEventer() {
         if (isOtherEnvironmentThanProd()) {
-            val innboksConsumer = createCountConsumer<GenericRecord>(EventType.INNBOKS, Kafka.innboksTopicName, environment)
             try {
-                countEventsAndReportMetrics(innboksConsumer, EventType.INNBOKS)
+                countEventsAndReportMetrics(innboksCountConsumer, EventType.INNBOKS)
 
             } catch (e: Exception) {
                 log.warn("Klarte ikke å telle og rapportere metrics for antall innboks-eventer", e)
@@ -59,52 +64,34 @@ class TopicEventCounterService(val environment: Environment, val topicMetricsPro
         }
     }
 
-    private suspend fun countAndReportMetricsForOppgaver() {
-        val oppgaveConsumer = createCountConsumer<GenericRecord>(EventType.OPPGAVE, Kafka.oppgaveTopicName, environment)
+    suspend fun countAndReportMetricsForOppgaver() {
         try {
-            countEventsAndReportMetrics(oppgaveConsumer, EventType.OPPGAVE)
+            countEventsAndReportMetrics(oppgaveCountConsumer, EventType.OPPGAVE)
 
         } catch (e: Exception) {
             log.warn("Klarte ikke å telle og rapportere metrics for antall oppgave-eventer", e)
         }
     }
 
-    private suspend fun countAndReportMetricsForDoneEvents() {
-        val doneConsumer = createCountConsumer<GenericRecord>(EventType.DONE, Kafka.doneTopicName, environment)
+    suspend fun countAndReportMetricsForDoneEvents() {
         try {
-            countEventsAndReportMetrics(doneConsumer, EventType.DONE)
+            countEventsAndReportMetrics(doneCountConsumer, EventType.DONE)
 
         } catch (e: Exception) {
             log.warn("Klarte ikke å telle og rapportere metrics for antall done-eventer", e)
         }
     }
 
-    fun <T> createCountConsumer(eventType: EventType,
-                                topic: String,
-                                environment: Environment,
-                                enableSecurity: Boolean = ConfigUtil.isCurrentlyRunningOnNais()): KafkaConsumer<Nokkel, T> {
-
-        val envWithMetricsGroupId = environment.copy(
-                counterGroupId = "${environment.counterGroupId}_metrics"
-        )
-        val kafkaProps = Kafka.counterConsumerProps(envWithMetricsGroupId, eventType, enableSecurity)
-        val consumer = KafkaConsumer<Nokkel, T>(kafkaProps)
-        consumer.subscribe(listOf(topic))
-        return consumer
-    }
-
-    suspend fun countEventsAndReportMetrics(kafkaConsumer: KafkaConsumer<Nokkel, GenericRecord>, eventType: EventType) {
+    private suspend fun countEventsAndReportMetrics(kafkaConsumer: KafkaConsumer<Nokkel, GenericRecord>, eventType: EventType) {
         topicMetricsProbe.runWithMetrics(eventType) {
-            kafkaConsumer.use { consumer ->
-                var records = consumer.poll(Duration.of(5000, ChronoUnit.MILLIS))
-                countBatch(records, this)
+            var records = kafkaConsumer.poll(Duration.of(5000, ChronoUnit.MILLIS))
+            countBatch(records, this)
 
-                while (records.foundRecords()) {
-                    records = kafkaConsumer.poll(Duration.of(500, ChronoUnit.MILLIS))
-                    countBatch(records, this)
-                }
-                consumer.resetTheGroupIdsOffsetToZero()
+            while (records.foundRecords()) {
+                records = kafkaConsumer.poll(Duration.of(500, ChronoUnit.MILLIS))
+                countBatch(records, this)
             }
+            kafkaConsumer.resetTheGroupIdsOffsetToZero()
         }
     }
 
@@ -115,8 +102,11 @@ class TopicEventCounterService(val environment: Environment, val topicMetricsPro
         }
     }
 
-}
+    fun closeAllConsumers() {
+        closeConsumer(beskjedCountConsumer)
+        closeConsumer(innboksCountConsumer)
+        closeConsumer(oppgaveCountConsumer)
+        closeConsumer(doneCountConsumer)
+    }
 
-fun <T> ConsumerRecords<Nokkel, T>.foundRecords(): Boolean {
-    return !isEmpty
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/submitter/PeriodicMetricsSubmitter.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/submitter/PeriodicMetricsSubmitter.kt
@@ -20,7 +20,7 @@ class PeriodicMetricsSubmitter(
 ) : CoroutineScope {
 
     private val log: Logger = LoggerFactory.getLogger(PeriodicDoneEventWaitingTableProcessor::class.java)
-    private val minutesToWait = Duration.ofMinutes(10)
+    private val minutesToWait = Duration.ofMinutes(5)
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default + job

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
@@ -107,7 +107,7 @@ object ConsumerRecordsObjectMother {
         return ConsumerRecords(records)
     }
 
-    fun wrapInConsumerRecords(singleRecord: ConsumerRecord<Nokkel, Done>, topicName: String = "dummyTopic"): ConsumerRecords<Nokkel, Done> {
+    fun wrapInConsumerRecords(singleRecord: ConsumerRecord<Nokkel, Done>): ConsumerRecords<Nokkel, Done> {
         return wrapInConsumerRecords(listOf(singleRecord))
     }
 


### PR DESCRIPTION
* Gjøres for å roe ned antallet logginnslag ifm start og stop av kafkaklientene for event-telling.
* For å se om minneforbrukte blir mer stabilt.
* Øker frekvensen for innrapportering av periodiske metrics.
* Hardkoder groupId-en for teller-klientene per eventtype, for å være sikker på å ikke få samme groupId som de vanlige kafka-konsumerene.