### PR TITLE
Byttet til korrekt rekkefølge på parameterene inn til TopicEventCounterService

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
@@ -80,7 +80,13 @@ class ApplicationContext {
     val innboksCountConsumer = createCountConsumer<GenericRecord>(EventType.INNBOKS, Kafka.innboksTopicName, environment)
     val oppgaveCountConsumer = createCountConsumer<GenericRecord>(EventType.OPPGAVE, Kafka.oppgaveTopicName, environment)
     val doneCountConsumer = createCountConsumer<GenericRecord>(EventType.DONE, Kafka.doneTopicName, environment)
-    val topicEventCounterService = TopicEventCounterService(topicMetricsProbe, beskjedCountConsumer, innboksCountConsumer, oppgaveCountConsumer, doneCountConsumer)
+    val topicEventCounterService = TopicEventCounterService(
+            topicMetricsProbe = topicMetricsProbe,
+            beskjedCountConsumer = beskjedCountConsumer,
+            innboksCountConsumer = innboksCountConsumer,
+            oppgaveCountConsumer = oppgaveCountConsumer,
+            doneCountConsumer = doneCountConsumer
+    )
 
     var periodicMetricsSubmitter = initializePeriodicMetricsSubmitter()
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
@@ -77,8 +77,8 @@ class ApplicationContext {
     val topicMetricsProbe = buildTopicMetricsProbe(environment, database)
 
     val beskjedCountConsumer = createCountConsumer<GenericRecord>(EventType.BESKJED, Kafka.beskjedTopicName, environment)
-    val oppgaveCountConsumer = createCountConsumer<GenericRecord>(EventType.OPPGAVE, Kafka.oppgaveTopicName, environment)
     val innboksCountConsumer = createCountConsumer<GenericRecord>(EventType.INNBOKS, Kafka.innboksTopicName, environment)
+    val oppgaveCountConsumer = createCountConsumer<GenericRecord>(EventType.OPPGAVE, Kafka.oppgaveTopicName, environment)
     val doneCountConsumer = createCountConsumer<GenericRecord>(EventType.DONE, Kafka.doneTopicName, environment)
     val topicEventCounterService = TopicEventCounterService(topicMetricsProbe, beskjedCountConsumer, innboksCountConsumer, oppgaveCountConsumer, doneCountConsumer)
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterService.kt
@@ -18,8 +18,8 @@ import java.time.temporal.ChronoUnit
 
 class TopicEventCounterService(val topicMetricsProbe: TopicMetricsProbe,
                                val beskjedCountConsumer: KafkaConsumer<Nokkel, GenericRecord>,
-                               val oppgaveCountConsumer: KafkaConsumer<Nokkel, GenericRecord>,
                                val innboksCountConsumer: KafkaConsumer<Nokkel, GenericRecord>,
+                               val oppgaveCountConsumer: KafkaConsumer<Nokkel, GenericRecord>,
                                val doneCountConsumer: KafkaConsumer<Nokkel, GenericRecord>) {
 
     private val log = LoggerFactory.getLogger(TopicEventCounterService::class.java)


### PR DESCRIPTION
Siden parameterene er av samme type var det mulig å sende inn feil, det førte til at for telling av oppgave-eventer så var det innboks-klienten som ble brukt.