### PR TITLE
Øker det maksimale polle-intervallet for kafka-konsumerene som brukes for å telle eventer

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Kafka.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Kafka.kt
@@ -49,10 +49,12 @@ object Kafka {
 
     fun counterConsumerProps(env: Environment, eventTypeToConsume: EventType, enableSecurity: Boolean = isCurrentlyRunningOnNais()): Properties {
         val groupIdAndEventType = "dn-aggregator_metrics_counter_" + eventTypeToConsume.eventType
+        val sixMinutes = 6 * 60 * 1000
         return Properties().apply {
             put(ConsumerConfig.GROUP_ID_CONFIG, groupIdAndEventType)
             put(ConsumerConfig.CLIENT_ID_CONFIG, groupIdAndEventType + getHostname(InetSocketAddress(0)))
             commonProps(env, enableSecurity)
+            put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, sixMinutes)
         }
     }
 


### PR DESCRIPTION
Default-verdien er fem minutter, øker den til seks minutter siden tellinger gjøres hvert femte minutt. Slik at vi har litt slakk.