### PR TITLE
Endrer beskjed-tekst limit til 300

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
@@ -50,7 +50,7 @@ data class Beskjed(
         validateNonNullFieldMaxLength(eventId, "eventId", 50)
         validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
         validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)
-        validateNonNullFieldMaxLength(tekst, "tekst", 500)
+        validateNonNullFieldMaxLength(tekst, "tekst", 300)
         validateMaxLength(link, "link", 200)
         validateSikkerhetsnivaa(sikkerhetsnivaa)
         validateNonNullFieldMaxLength(uid, "uid", 100)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
@@ -49,7 +49,7 @@ class BeskjedTransformerTest {
 
     @Test
     fun `should throw FieldValidationException if text field is too long`() {
-        val tooLongText = "A".repeat(501)
+        val tooLongText = "A".repeat(301)
         val event = AvroBeskjedObjectMother.createBeskjedWithText(tooLongText)
 
         invoking {
@@ -61,7 +61,7 @@ class BeskjedTransformerTest {
 
     @Test
     fun `should allow text length up to the limit`() {
-        val textWithMaxAllowedLength = "B".repeat(500)
+        val textWithMaxAllowedLength = "B".repeat(300)
         val event = AvroBeskjedObjectMother.createBeskjedWithText(textWithMaxAllowedLength)
 
         runBlocking {


### PR DESCRIPTION
Beskjed-tekst limit er satt til 300.

Fyi, i prod er fortsatt den lengste beskjeden 290 tegn.