### PR TITLE
Sørger for å gjenbruke kafka-konsumerene som brukes til telling av eventer

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterServiceIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterServiceIT.kt
@@ -9,6 +9,7 @@ import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMoth
 import no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util.KafkaTestUtil
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.config.KafkaConsumerSetup.createCountConsumer
+import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.closeConsumer
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldEqualTo
@@ -58,7 +59,7 @@ class TopicEventCounterServiceIT {
         metricsSession.getTotalNumber() `should be equal to` events.size * 3
         metricsSession.getNumberOfUniqueEvents() `should be equal to` events.size
 
-        service.closeAllConsumers()
+        closeConsumer(beskjedCountConsumer)
     }
 
     @Test
@@ -75,7 +76,7 @@ class TopicEventCounterServiceIT {
 
         `tell og verifiser korrekte antall eventer flere ganger paa rad`(service, metricsSession)
 
-        service.closeAllConsumers()
+        closeConsumer(beskjedCountConsumer)
     }
 
     private fun `tell og verifiser korrekte antall eventer flere ganger paa rad`(service: TopicEventCounterService,

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
@@ -20,6 +20,7 @@ import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.DbEventCount
 import no.nav.personbruker.dittnav.eventaggregator.metrics.db.count.MetricsRepository
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.KafkaEventCounterService
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.KafkaTopicEventCounterService
+import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.closeConsumer
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.createCountConsumer
 import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.topic.TopicEventCounterService
 import no.nav.personbruker.dittnav.eventaggregator.metrics.submitter.PeriodicMetricsSubmitter
@@ -66,9 +67,6 @@ class ApplicationContext {
 
     val healthService = HealthService(this)
 
-    val kafkaEventCounterService = KafkaEventCounterService(environment)
-    val kafkaTopicEventCounterService = KafkaTopicEventCounterService(environment)
-
     val metricsRepository = MetricsRepository(database)
     val cacheEventCounterService = CacheEventCounterService(environment, metricsRepository)
     val dbEventCountingMetricsProbe = buildDbEventCountingMetricsProbe(environment, database)
@@ -87,6 +85,13 @@ class ApplicationContext {
             oppgaveCountConsumer = oppgaveCountConsumer,
             doneCountConsumer = doneCountConsumer
     )
+    val kafkaEventCounterService = KafkaEventCounterService(
+            beskjedCountConsumer = beskjedCountConsumer,
+            innboksCountConsumer = innboksCountConsumer,
+            oppgaveCountConsumer = oppgaveCountConsumer,
+            doneCountConsumer = doneCountConsumer
+    )
+    val kafkaTopicEventCounterService = KafkaTopicEventCounterService(environment)
 
     var periodicMetricsSubmitter = initializePeriodicMetricsSubmitter()
 
@@ -153,5 +158,12 @@ class ApplicationContext {
 
     private fun initializePeriodicMetricsSubmitter(): PeriodicMetricsSubmitter =
             PeriodicMetricsSubmitter(dbEventCounterService, topicEventCounterService)
+
+    fun closeAllKafkaCountConsumers() {
+        closeConsumer(beskjedCountConsumer)
+        closeConsumer(innboksCountConsumer)
+        closeConsumer(oppgaveCountConsumer)
+        closeConsumer(doneCountConsumer)
+    }
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
@@ -50,7 +50,6 @@ private fun Application.configureShutdownHook(appContext: ApplicationContext) {
             appContext.periodicMetricsSubmitter.stop()
         }
         appContext.database.dataSource.close()
-        appContext.kafkaEventCounterService.closeAllConsumers()
-        appContext.topicEventCounterService.closeAllConsumers()
+        appContext.closeAllKafkaCountConsumers()
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/kafkaCountingUtil.kt
@@ -46,7 +46,7 @@ fun countUniqueEvents(consumer: KafkaConsumer<Nokkel, GenericRecord>, eventType:
     val start = Instant.now()
     var records = consumer.poll(Duration.of(5000, ChronoUnit.MILLIS))
     var duplicationCounter: Long = 0
-    val uniqueEvents = HashSet<UniqueKafkaEventIdentifier>(25000000)
+    val uniqueEvents = HashSet<UniqueKafkaEventIdentifier>(5000000)
 
     duplicationCounter += countBatch(records, uniqueEvents)
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/kafka/topic/TopicEventCounterService.kt
@@ -8,7 +8,6 @@ import no.nav.personbruker.dittnav.eventaggregator.common.kafka.foundRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.resetTheGroupIdsOffsetToZero
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.config.isOtherEnvironmentThanProd
-import no.nav.personbruker.dittnav.eventaggregator.metrics.kafka.closeConsumer
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -100,13 +99,6 @@ class TopicEventCounterService(val topicMetricsProbe: TopicMetricsProbe,
             val event = UniqueKafkaEventIdentifierTransformer.toInternal(record)
             metricsSession.countEvent(event)
         }
-    }
-
-    fun closeAllConsumers() {
-        closeConsumer(beskjedCountConsumer)
-        closeConsumer(innboksCountConsumer)
-        closeConsumer(oppgaveCountConsumer)
-        closeConsumer(doneCountConsumer)
     }
 
 }


### PR DESCRIPTION
Da slipper vi at det forsøkes å opprette nye konsumere med samme groupId.