### PR TITLE
Ikke rapporter periodiske metrikker som standard

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
@@ -38,7 +38,6 @@ private fun Application.configureStartupHook(appContext: ApplicationContext) {
         Flyway.runFlywayMigrations(appContext.environment)
         KafkaConsumerSetup.startAllKafkaPollers(appContext)
         appContext.periodicDoneEventWaitingTableProcessor.start()
-        appContext.periodicMetricsSubmitter.start()
     }
 }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/health/HealthService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/health/HealthService.kt
@@ -11,8 +11,7 @@ class HealthService(private val applicationContext: ApplicationContext) {
                 applicationContext.innboksConsumer.status(),
                 applicationContext.oppgaveConsumer.status(),
                 applicationContext.doneConsumer.status(),
-                applicationContext.periodicDoneEventWaitingTableProcessor.status(),
-                applicationContext.periodicMetricsSubmitter.status()
+                applicationContext.periodicDoneEventWaitingTableProcessor.status()
         )
     }
 }


### PR DESCRIPTION
Appen trenger ikke lengre å kjøre periodiske metrikker som standard.

De periodiske metrikkene har blitt flyttet ut i en egen app `dittnav-periodic-metrics-reporter`. I det den nye appen har tatt helt over skal all kode for periodiske metrikker fjernes fra aggregatoren.