### PR TITLE
Pauser konsument for å se om en periodisk auth exception løser seg ve…

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
@@ -28,6 +28,10 @@ class Consumer<T>(
 
     private val log: Logger = LoggerFactory.getLogger(Consumer::class.java)
 
+    companion object {
+        private const val ONE_MINUTE_IN_MS = 60000L
+    }
+
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default + job
 
@@ -91,7 +95,7 @@ class Consumer<T>(
 
         } catch (tae: TopicAuthorizationException) {
             log.warn("Pauser polling i ett minutt, er ikke autorisert for å lese: ${tae.unauthorizedTopics()}", tae)
-            delay(60000)
+            delay(ONE_MINUTE_IN_MS)
 
         } catch (e: Exception) {
             log.error("Noe uventet feilet, stopper polling. Topic: $topic", e)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
@@ -12,6 +12,7 @@ import no.nav.personbruker.dittnav.eventaggregator.health.Status
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.errors.RetriableException
+import org.apache.kafka.common.errors.TopicAuthorizationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -87,6 +88,10 @@ class Consumer<T>(
 
         } catch (ce: CancellationException) {
             log.info("Denne coroutine-en ble stoppet. ${ce.message}", ce)
+
+        } catch (tae: TopicAuthorizationException) {
+            log.warn("Pauser polling i ett minutt, er ikke autorisert for å lese: ${tae.unauthorizedTopics()}", tae)
+            delay(60000)
 
         } catch (e: Exception) {
             log.error("Noe uventet feilet, stopper polling. Topic: $topic", e)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTest.kt
@@ -188,7 +188,9 @@ class ConsumerTest {
             consumer.startPolling()
             delay(100)
             consumer.status().status `should equal` Status.OK
+            consumer.stopPolling()
         }
+        verify(exactly = 0) { kafkaConsumer.commitSync() }
     }
 
     private suspend fun `Vent litt for aa bevise at det IKKE fortsettes aa polle`() {


### PR DESCRIPTION
…d neste polling.

Kafka sin `org.apache.kafka.clients.consumer.KafkaConsumer` kan noen ganger kaste en `TopicAuthorizationException` og [logge](https://github.com/apache/kafka/blob/9c8f75c4b624084c954b4da69f092211a9ac4689/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java#L1304) at konsumenten ikke er autorisert til å lese en partition (f.eks nr. 3). 

Siden vi skal være autentiserte og autoriserte, tyder det på at dette er en midlertidig feil som kanskje kan løse seg ved neste polling. Denne PR-en forsøker derfor å omgå denne feilen ved å vente ett minutt før neste polling istedenfor å stoppe konsumenten.

PB-459 Pause konsument når det oppstår en autoriseringsfeil.