### PR TITLE
Justert logging rundt oppslag på mapping for systembrukere

### DIFF
--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/ProducerNameResolverTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/ProducerNameResolverTest.kt
@@ -66,7 +66,8 @@ internal class ProducerNameResolverTest {
     fun `skal trigge oppdatering av cachen hvis produsentnavn ikke ble funnet i cache`() {
         runBlocking {
             producerNameResolver.getProducerNameAlias("x-ukjent")
-            coVerify(exactly = 1) { database.queryWithExceptionTranslation<List<Produsent>>(any()) }
+            producerNameResolver.getProducerNameAlias("x-ukjent")
+            coVerify(exactly = 2) { database.queryWithExceptionTranslation<List<Produsent>>(any()) }
         }
     }
 }


### PR DESCRIPTION
* Logger på info-nivå for forventede oppdateringer av cache.
* Logger kun på warning-nivå hvis en systembruker verken ble funnet i cache-en eller databasen.