### PR TITLE
Sørger for at samme name scrubber brukes i hele appen

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/ApplicationContext.kt
@@ -11,6 +11,8 @@ import no.nav.personbruker.dittnav.eventaggregator.done.PeriodicDoneEventWaiting
 import no.nav.personbruker.dittnav.eventaggregator.health.HealthService
 import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksEventService
 import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksRepository
+import no.nav.personbruker.dittnav.eventaggregator.metrics.ProducerNameResolver
+import no.nav.personbruker.dittnav.eventaggregator.metrics.ProducerNameScrubber
 import no.nav.personbruker.dittnav.eventaggregator.metrics.buildDBMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.metrics.buildEventMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveEventService
@@ -24,8 +26,10 @@ class ApplicationContext {
     val environment = Environment()
     val database: Database = PostgresDatabase(environment)
 
-    val eventMetricsProbe = buildEventMetricsProbe(environment, database)
-    val dbMetricsProbe = buildDBMetricsProbe(environment, database)
+    val nameResolver = ProducerNameResolver(database)
+    val nameScrubber = ProducerNameScrubber(nameResolver)
+    val eventMetricsProbe = buildEventMetricsProbe(environment, nameScrubber)
+    val dbMetricsProbe = buildDBMetricsProbe(environment, nameScrubber)
 
     val beskjedRepository = BeskjedRepository(database)
     val beskjedPersistingService = BrukernotifikasjonPersistingService(beskjedRepository)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricsProbeSetup.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricsProbeSetup.kt
@@ -1,22 +1,17 @@
 package no.nav.personbruker.dittnav.eventaggregator.metrics
 
-import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.config.Environment
 import no.nav.personbruker.dittnav.eventaggregator.metrics.db.DBMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.InfluxMetricsReporter
 import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.SensuClient
 
-fun buildEventMetricsProbe(environment: Environment, database: Database): EventMetricsProbe {
+fun buildEventMetricsProbe(environment: Environment, nameScrubber: ProducerNameScrubber): EventMetricsProbe {
     val metricsReporter = resolveMetricsReporter(environment)
-    val nameResolver = ProducerNameResolver(database)
-    val nameScrubber = ProducerNameScrubber(nameResolver)
     return EventMetricsProbe(metricsReporter, nameScrubber)
 }
 
-fun buildDBMetricsProbe(environment: Environment, database: Database): DBMetricsProbe {
+fun buildDBMetricsProbe(environment: Environment, nameScrubber: ProducerNameScrubber): DBMetricsProbe {
     val metricsReporter = resolveMetricsReporter(environment)
-    val nameResolver = ProducerNameResolver(database)
-    val nameScrubber = ProducerNameScrubber(nameResolver)
     return DBMetricsProbe(metricsReporter, nameScrubber)
 }
 


### PR DESCRIPTION
Dette er viktig siden hver name-scrubber-en har en cache, og denne cache-en ønsker vi bare en versjon av. For å oppdatere cache-en må det gjøres et database-kall, og dette behovet har nå blitt halvert.