### PR TITLE
Senker midlertidig loggnivået for duplikat-advarsler fra en spesifikk produsent som sender mye duplikater

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
@@ -76,7 +76,7 @@ class BeskjedEventService(
 
             val msg = """Traff $constraintErrors feil på duplikate eventId-er ved behandling av $totalEntities beskjed-eventer.
                            | Feilene ble produsert av: ${getNumberDuplicateKeysByProducer()}""".trimMargin()
-            log.warn(msg)
+            logAsWarningForAllProducersExceptForFpinfoHistorikk(msg)
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
@@ -86,7 +86,7 @@ class DoneEventService(
 
             val msg = """Traff $constraintErrors feil på duplikate eventId-er ved behandling av $totalEntities done-eventer.
                            | Feilene ble produsert av: ${getNumberDuplicateKeysByProducer()}""".trimMargin()
-            log.warn(msg)
+            logAsWarningForAllProducersExceptForFpinfoHistorikk(msg)
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
@@ -75,7 +75,7 @@ class InnboksEventService(
 
             val msg = """Traff $constraintErrors feil på duplikate eventId-er ved behandling av $totalEntities innboks-eventer.
                            | Feilene ble produsert av: ${getNumberDuplicateKeysByProducer()}""".trimMargin()
-            log.warn(msg)
+            logAsWarningForAllProducersExceptForFpinfoHistorikk(msg)
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
@@ -75,7 +75,7 @@ class OppgaveEventService(
 
             val msg = """Traff $constraintErrors feil på duplikate eventId-er ved behandling av $totalEntities oppgave-eventer.
                            | Feilene ble produsert av: ${getNumberDuplicateKeysByProducer()}""".trimMargin()
-            log.warn(msg)
+            logAsWarningForAllProducersExceptForFpinfoHistorikk(msg)
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/EventMetricsSessionTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/EventMetricsSessionTest.kt
@@ -1,0 +1,34 @@
+package no.nav.personbruker.dittnav.eventaggregator.metrics
+
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import org.amshove.kluent.`should be`
+import org.junit.jupiter.api.Test
+
+internal class EventMetricsSessionTest {
+
+    @Test
+    fun `Skal returnere true hvis det kun er fpinfo-historik som har sendt duplikat`() {
+        val session = EventMetricsSession(EventType.BESKJED)
+        session.countDuplicateEventKeysByProducer("blalbafpinfo-historikk")
+
+        session.isDuplicatesFromFpinfoHistorikkOnly() `should be` true
+    }
+
+    @Test
+    fun `Skal returnere false hvis det er flere produsenter, inkludert fpinfo-historik, som har sendt duplikater`() {
+        val session = EventMetricsSession(EventType.BESKJED)
+        session.countDuplicateEventKeysByProducer("blablafpinfo-historikk")
+        session.countDuplicateEventKeysByProducer("enAnnenProdusent")
+
+        session.isDuplicatesFromFpinfoHistorikkOnly() `should be` false
+    }
+
+    @Test
+    fun `Skal returnere false hvis det er en annen produsent enn fpinfo-historik som har sendt duplikat`() {
+        val session = EventMetricsSession(EventType.BESKJED)
+        session.countDuplicateEventKeysByProducer("enAnnenProdusent")
+
+        session.isDuplicatesFromFpinfoHistorikkOnly() `should be` false
+    }
+
+}


### PR DESCRIPTION
Dette gjør at vi slipper å få alarmer i Slack på dette, fram til produsenten har sluttet å sende duplikater.