### PR TITLE
Retter feil som gjorde at appen ikke startet i Docker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ tasks.withType<KotlinCompile> {
 repositories {
     jcenter()
     mavenCentral()
-    maven("http://packages.confluent.io/maven")
+    maven("https://packages.confluent.io/maven")
     mavenLocal()
 }
 
@@ -71,10 +71,19 @@ application {
 
 tasks {
     withType<Jar> {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Tillater ikke duplikater i jar-fila, slik som kreves for å være kompatible med Gradle 7.
         manifest {
             attributes["Main-Class"] = application.mainClassName
         }
-        from(configurations.runtime.get().map { if (it.isDirectory) it else zipTree(it) })
+        from(sourceSets.main.get().output)
+        dependsOn(configurations.runtimeClasspath)
+        from({
+            configurations.runtimeClasspath.get().filter { file ->
+                file.name.endsWith("jar")
+            }.map { fileToAddToZip ->
+                zipTree(fileToAddToZip)
+            }
+        })
     }
 
     withType<Test> {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Oppgraderte til Gradle 6.6.1, som er strengere enn tidligere versjoner. Dette førte til at det kom noen nye warnings, bla at det ikke er lov med duplikater av filer i JAR-filer. Har gjort justeringer i build.gradle.kts for å imøtekomme dette.

Har verifisert at denne branch-en kan startes både på Nais i Q1 og i docker-compose.