### PR TITLE
Øker default.api.timeout.ms med ett minutt for å se om det fikser en …

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Kafka.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Kafka.kt
@@ -61,6 +61,7 @@ object Kafka {
     }
 
     private fun Properties.commonProps(env: Environment, enableSecurity: Boolean) {
+        val twoMinutes = 2 * 60 * 1000
         put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, env.bootstrapServers)
         put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, env.schemaRegistryUrl)
         put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
@@ -68,6 +69,7 @@ object Kafka {
         put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, SwallowSerializationErrorsAvroDeserializer::class.java)
         put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true)
         put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, twoMinutes)
         if (enableSecurity) {
             putAll(credentialProps(env))
         }


### PR DESCRIPTION
…TimeoutException som stopper konsumenter.

En konsument kan stoppe når:

* `commitSync()` kaster en TimeoutException og
* `committed()` kaster en TimeoutException

For å være sikker på at dette ikke skjer igjen økes timeout-verdien med ett minutt for `commitSync` og `committed` (se KAFKA-8311).
