### PR TITLE
Løftet alle avhengigheter, unntatt Kluent og Mockk

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,20 +81,11 @@ tasks {
     }
 
     register("runServer", JavaExec::class) {
-        environment("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
-        environment("KAFKA_SCHEMAREGISTRY_SERVERS", "http://localhost:8081")
-        environment("SERVICEUSER_USERNAME", "username")
-        environment("SERVICEUSER_PASSWORD", "password")
-        environment("GROUP_ID", "dittnav_events")
-        environment("DB_HOST", "localhost:5432")
-        environment("DB_NAME", "dittnav-event-cache-preprod")
-        environment("DB_PASSWORD", "testpassword")
-        environment("DB_MOUNT_PATH", "notUsedOnLocalhost")
-        environment("NAIS_CLUSTER_NAME", "dev-sbs")
-        environment("NAIS_NAMESPACE", "q1")
-        environment("SENSU_HOST", "stub")
-        environment("SENSU_PORT", "")
-        environment("PRODUCER_ALIASES", "")
+        println("Setting default environment variables for running with DittNAV docker-compose")
+        DockerComposeDefaults.environomentVariables.forEach { (name, value) ->
+            println("Setting the environment variable $name")
+            environment(name, value)
+        }
 
         main = application.mainClassName
         classpath = sourceSets["main"].runtimeClasspath

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2020.09.21-16.19-0e04a3fcc2e7"
+val dittNavDependenciesVersion = "2020.10.07-09.04-90cc1e530b61"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaConsumerUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaConsumerUtil.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util
 
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
@@ -34,7 +34,7 @@ object KafkaConsumerUtil {
                             set(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroDeserializer")
                             set(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroDeserializer")
                             set(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true)
-                            set(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
+                            set(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
                             set(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true)
                             set(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
                             set(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 4)

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaProducerUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaProducerUtil.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util
 
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
 import kotlinx.coroutines.withTimeoutOrNull
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.common.JAAS_PLAIN_LOGIN
@@ -16,61 +16,85 @@ import java.util.*
 object KafkaProducerUtil {
 
     suspend fun kafkaAvroProduce(
-            brokersURL: String,
-            schemaRegistryUrl: String,
-            topic: String,
-            user: String,
-            pwd: String,
-            data: Map<Nokkel, GenericRecord>
+        brokersURL: String,
+        schemaRegistryUrl: String,
+        topic: String,
+        user: String,
+        pwd: String,
+        data: Map<Nokkel, GenericRecord>
     ): Boolean =
-            try {
-                KafkaProducer<Nokkel, GenericRecord>(
-                        Properties().apply {
-                            set(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokersURL)
-                            set(ProducerConfig.CLIENT_ID_CONFIG, "funKafkaAvroProduce")
-                            set(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroSerializer")
-                            set(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroSerializer")
-                            set(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
-                            set(ProducerConfig.ACKS_CONFIG, "all")
-                            set(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
-                            set(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 500)
-                            set(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT")
-                            set(SaslConfigs.SASL_MECHANISM, "PLAIN")
-                            set(SaslConfigs.SASL_JAAS_CONFIG, "$JAAS_PLAIN_LOGIN $JAAS_REQUIRED username=\"$user\" password=\"$pwd\";")
-                        }
-                ).use { p ->
-                    withTimeoutOrNull(10_000) {
-                        data.forEach { k, v -> p.send(ProducerRecord(topic, k, v)).get() }
-                        true
-                    } ?: false
+        try {
+            KafkaProducer<Nokkel, GenericRecord>(
+                Properties().apply {
+                    set(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokersURL)
+                    set(ProducerConfig.CLIENT_ID_CONFIG, "funKafkaAvroProduce")
+                    set(
+                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                        "io.confluent.kafka.serializers.KafkaAvroSerializer"
+                    )
+                    set(
+                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                        "io.confluent.kafka.serializers.KafkaAvroSerializer"
+                    )
+                    set(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
+                    set(ProducerConfig.ACKS_CONFIG, "all")
+                    set(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
+                    set(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 500)
+                    set(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT")
+                    set(SaslConfigs.SASL_MECHANISM, "PLAIN")
+                    set(
+                        SaslConfigs.SASL_JAAS_CONFIG,
+                        "$JAAS_PLAIN_LOGIN $JAAS_REQUIRED username=\"$user\" password=\"$pwd\";"
+                    )
                 }
-            } catch (e: Exception) {
-                false
+            ).use { p ->
+                withTimeoutOrNull(10_000) {
+                    data.forEach { k, v -> p.send(ProducerRecord(topic, k, v)).get() }
+                    true
+                } ?: false
             }
+        } catch (e: Exception) {
+            false
+        }
 
-    suspend fun kafkaProduce(brokersURL: String, topic: String, user: String, pwd: String, data: Map<String, String>): Boolean =
-            try {
-                KafkaProducer<String, String>(
-                        Properties().apply {
-                            set(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokersURL)
-                            set(ProducerConfig.CLIENT_ID_CONFIG, "funKafkaProduce")
-                            set(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
-                            set(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
-                            set(ProducerConfig.ACKS_CONFIG, "all")
-                            set(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
-                            set(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 500)
-                            set(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT")
-                            set(SaslConfigs.SASL_MECHANISM, "PLAIN")
-                            set(SaslConfigs.SASL_JAAS_CONFIG, "$JAAS_PLAIN_LOGIN $JAAS_REQUIRED username=\"$user\" password=\"$pwd\";")
-                        }
-                ).use { p ->
-                    withTimeoutOrNull(10_000) {
-                        data.forEach { k, v -> p.send(ProducerRecord(topic, k, v)).get() }
-                        true
-                    } ?: false
+    suspend fun kafkaProduce(
+        brokersURL: String,
+        topic: String,
+        user: String,
+        pwd: String,
+        data: Map<String, String>
+    ): Boolean =
+        try {
+            KafkaProducer<String, String>(
+                Properties().apply {
+                    set(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokersURL)
+                    set(ProducerConfig.CLIENT_ID_CONFIG, "funKafkaProduce")
+                    set(
+                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                        "org.apache.kafka.common.serialization.StringSerializer"
+                    )
+                    set(
+                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                        "org.apache.kafka.common.serialization.StringSerializer"
+                    )
+                    set(ProducerConfig.ACKS_CONFIG, "all")
+                    set(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
+                    set(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 500)
+                    set(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT")
+                    set(SaslConfigs.SASL_MECHANISM, "PLAIN")
+                    set(
+                        SaslConfigs.SASL_JAAS_CONFIG,
+                        "$JAAS_PLAIN_LOGIN $JAAS_REQUIRED username=\"$user\" password=\"$pwd\";"
+                    )
                 }
-            } catch (e: Exception) {
-                false
+            ).use { p ->
+                withTimeoutOrNull(10_000) {
+                    data.forEach { k, v -> p.send(ProducerRecord(topic, k, v)).get() }
+                    true
+                } ?: false
             }
+        } catch (e: Exception) {
+            false
+        }
 
 }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaProducerUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaProducerUtil.kt
@@ -28,24 +28,15 @@ object KafkaProducerUtil {
                 Properties().apply {
                     set(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokersURL)
                     set(ProducerConfig.CLIENT_ID_CONFIG, "funKafkaAvroProduce")
-                    set(
-                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                        "io.confluent.kafka.serializers.KafkaAvroSerializer"
-                    )
-                    set(
-                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                        "io.confluent.kafka.serializers.KafkaAvroSerializer"
-                    )
+                    set(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroSerializer")
+                    set(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroSerializer")
                     set(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
                     set(ProducerConfig.ACKS_CONFIG, "all")
                     set(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
                     set(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 500)
                     set(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT")
                     set(SaslConfigs.SASL_MECHANISM, "PLAIN")
-                    set(
-                        SaslConfigs.SASL_JAAS_CONFIG,
-                        "$JAAS_PLAIN_LOGIN $JAAS_REQUIRED username=\"$user\" password=\"$pwd\";"
-                    )
+                    set(SaslConfigs.SASL_JAAS_CONFIG, "$JAAS_PLAIN_LOGIN $JAAS_REQUIRED username=\"$user\" password=\"$pwd\";")
                 }
             ).use { p ->
                 withTimeoutOrNull(10_000) {
@@ -69,23 +60,14 @@ object KafkaProducerUtil {
                 Properties().apply {
                     set(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokersURL)
                     set(ProducerConfig.CLIENT_ID_CONFIG, "funKafkaProduce")
-                    set(
-                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                        "org.apache.kafka.common.serialization.StringSerializer"
-                    )
-                    set(
-                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                        "org.apache.kafka.common.serialization.StringSerializer"
-                    )
+                    set(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
+                    set(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
                     set(ProducerConfig.ACKS_CONFIG, "all")
                     set(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
                     set(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 500)
                     set(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT")
                     set(SaslConfigs.SASL_MECHANISM, "PLAIN")
-                    set(
-                        SaslConfigs.SASL_JAAS_CONFIG,
-                        "$JAAS_PLAIN_LOGIN $JAAS_REQUIRED username=\"$user\" password=\"$pwd\";"
-                    )
+                    set(SaslConfigs.SASL_JAAS_CONFIG, "$JAAS_PLAIN_LOGIN $JAAS_REQUIRED username=\"$user\" password=\"$pwd\";")
                 }
             ).use { p ->
                 withTimeoutOrNull(10_000) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
@@ -5,8 +5,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 
 fun <T> KafkaConsumer<Nokkel, T>.rollbackToLastCommitted() {
-    assignment().forEach { partition ->
-        val lastCommitted = committed(partition)
+    val assignedPartitions = assignment()
+    val partitionCommittedInfo = committed(assignedPartitions)
+    partitionCommittedInfo.forEach { (partition, lastCommitted) ->
         seek(partition, lastCommitted.offset())
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
@@ -11,13 +11,3 @@ fun <T> KafkaConsumer<Nokkel, T>.rollbackToLastCommitted() {
         seek(partition, lastCommitted.offset())
     }
 }
-
-fun <T> KafkaConsumer<Nokkel, T>.resetTheGroupIdsOffsetToZero() {
-    assignment().forEach { partition ->
-        seek(partition, 0)
-    }
-}
-
-fun <T> ConsumerRecords<Nokkel, T>.foundRecords(): Boolean {
-    return !isEmpty
-}


### PR DESCRIPTION
Har løfte alle avhengigheter unntatt Kluent og Mockk, fordi de hadde mange api-edringer. Venter derfor med å endre disse, slik at vi ser sikre på at testene fungerer som før.

Det er lettere å lese denne PR-en ved å deaktivere [visning av whitespace-endringer](https://github.com/navikt/dittnav-event-aggregator/pull/125/files?diff=unified&w=1).