### PR TITLE
Tatt i bruk ny versjon av Kluent

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2020.10.07-09.04-90cc1e530b61"
+val dittNavDependenciesVersion = "2020.10.07-12.16-dae8cb1e56ed"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/EndToEndTestIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/EndToEndTestIT.kt
@@ -17,8 +17,7 @@ import no.nav.personbruker.dittnav.eventaggregator.metrics.ProducerNameResolver
 import no.nav.personbruker.dittnav.eventaggregator.metrics.ProducerNameScrubber
 import no.nav.personbruker.dittnav.eventaggregator.metrics.StubMetricsReporter
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
-import org.amshove.kluent.`should equal`
-import org.amshove.kluent.shouldEqualTo
+import org.amshove.kluent.`should be equal to`
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
@@ -58,7 +57,7 @@ class EndToEndTestIT {
 
     @Test
     fun `Kafka instansen i minnet har blitt staret`() {
-        embeddedEnv.serverPark.status `should equal` KafkaEnvironment.ServerParkStatus.Started
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
     }
 
     @Test
@@ -69,14 +68,14 @@ class EndToEndTestIT {
         runBlocking {
             database.dbQuery {
                 getAllBeskjed().size
-            } `should equal` events.size
+            } `should be equal to` events.size
         }
     }
 
     fun `Produserer noen testeventer`() {
         runBlocking {
             KafkaTestUtil.produceEvents(testEnvironment, topicen, events)
-        } shouldEqualTo true
+        } `should be equal to` true
     }
 
     fun `Les inn alle eventene og verifiser at de har blitt lagt til i databasen`() {

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTeardownQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTeardownQueriesTest.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.beskjed
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventaggregator.common.database.H2Database
 import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
 class BeskjedTeardownQueriesTest {
@@ -23,7 +23,7 @@ class BeskjedTeardownQueriesTest {
 
             `Slett alle beskjedelementer fra databasen`()
             val skalIkkeHaElementerIDatabasen = database.dbQuery { getAllBeskjed() }
-            skalIkkeHaElementerIDatabasen.isEmpty() `should equal` true
+            skalIkkeHaElementerIDatabasen.isEmpty() `should be equal to` true
         }
     }
 

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueriesTest.kt
@@ -80,7 +80,7 @@ class beskjedQueriesTest {
     fun `Finner cachet Beskjed-event med Id`() {
         runBlocking {
             val result = database.dbQuery { beskjed2.id?.let { getBeskjedById(it) } }
-            result `should equal` beskjed2
+            result `should be equal to` beskjed2
         }
     }
 
@@ -114,7 +114,7 @@ class beskjedQueriesTest {
     fun `Finner cachet Beskjed-event med eventId`() {
         runBlocking {
             val result = database.dbQuery { getBeskjedByEventId(eventId) }
-            result `should equal` beskjed2
+            result `should be equal to` beskjed2
         }
     }
 
@@ -140,8 +140,8 @@ class beskjedQueriesTest {
             val beskjed1FraDb = database.dbQuery { getBeskjedByEventId(beskjed1.eventId) }
             val beskjed2FraDb = database.dbQuery { getBeskjedByEventId(beskjed2.eventId) }
 
-            beskjed1FraDb.eventId `should equal` beskjed1.eventId
-            beskjed2FraDb.eventId `should equal` beskjed2.eventId
+            beskjed1FraDb.eventId `should be equal to` beskjed1.eventId
+            beskjed2FraDb.eventId `should be equal to` beskjed2.eventId
 
             database.dbQuery { deleteBeskjedWithEventId(beskjed1.eventId) }
             database.dbQuery { deleteBeskjedWithEventId(beskjed2.eventId) }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/AvroBasicKafkaEmbeddedTesting.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/AvroBasicKafkaEmbeddedTesting.kt
@@ -2,15 +2,14 @@ package no.nav.personbruker.dittnav.eventaggregator.common.database.kafka
 
 import kotlinx.coroutines.runBlocking
 import no.nav.common.KafkaEnvironment
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util.KafkaConsumerUtil
 import no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util.KafkaProducerUtil
 import no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util.KafkaTestUtil
 import no.nav.personbruker.dittnav.eventaggregator.config.Kafka
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldContainAll
-import org.amshove.kluent.shouldEqualTo
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 
@@ -41,7 +40,7 @@ class AvroBasicKafkaEmbeddedTesting {
 
     @Test
     fun `Kafka instansen i minnet har blitt staret`() {
-        embeddedEnv.serverPark.status `should equal` KafkaEnvironment.ServerParkStatus.Started
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
     }
 
     @Test
@@ -65,7 +64,7 @@ class AvroBasicKafkaEmbeddedTesting {
                     username,
                     password,
                     events)
-        } shouldEqualTo true
+        } `should be equal to` true
     }
 
 }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/StringBasicKafkaEmbeddedTesting.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/StringBasicKafkaEmbeddedTesting.kt
@@ -5,9 +5,8 @@ import no.nav.common.JAASCredential
 import no.nav.common.KafkaEnvironment
 import no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util.KafkaConsumerUtil
 import no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util.KafkaProducerUtil
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldContainAll
-import org.amshove.kluent.shouldEqualTo
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 
@@ -24,9 +23,9 @@ class StringBasicKafkaEmbeddedTesting {
     private val username = "srvkafkaclient"
     private val password = "kafkaclient"
     private val embeddedEnv = KafkaEnvironment(
-            topicNames = listOf(topicen),
-            withSecurity = true,
-            users = listOf(JAASCredential(username, password))
+        topicNames = listOf(topicen),
+        withSecurity = true,
+        users = listOf(JAASCredential(username, password))
     )
     private val kafkaBrokerUrl = embeddedEnv.brokersURL.substringAfterLast("/")
 
@@ -43,29 +42,33 @@ class StringBasicKafkaEmbeddedTesting {
 
     @Test
     fun `Kafka-instansen i minnet har blitt staret`() {
-        embeddedEnv.serverPark.status `should equal` KafkaEnvironment.ServerParkStatus.Started
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
     }
 
     @Test
     fun `Skal produsere og konsumere en meldinger som kun er en string`() {
         `produser string-eventer`()
         runBlocking {
-            KafkaConsumerUtil.kafkaConsume(kafkaBrokerUrl,
-                    topicen,
-                    username,
-                    password,
-                    events.size)
+            KafkaConsumerUtil.kafkaConsume(
+                kafkaBrokerUrl,
+                topicen,
+                username,
+                password,
+                events.size
+            )
         } shouldContainAll events
     }
 
     private fun `produser string-eventer`() {
         runBlocking {
-            KafkaProducerUtil.kafkaProduce(kafkaBrokerUrl,
-                    topicen,
-                    username,
-                    password,
-                    events)
-        } shouldEqualTo true
+            KafkaProducerUtil.kafkaProduce(
+                kafkaBrokerUrl,
+                topicen,
+                username,
+                password,
+                events
+            )
+        } `should be equal to` true
     }
 
 }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/MultipleTopicsConsumerTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/MultipleTopicsConsumerTest.kt
@@ -21,7 +21,7 @@ import no.nav.personbruker.dittnav.eventaggregator.innboks.AvroInnboksObjectMoth
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import no.nav.personbruker.dittnav.eventaggregator.oppgave.AvroOppgaveObjectMother
 import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 
@@ -52,7 +52,7 @@ class MultipleTopicsConsumerTest {
 
     @Test
     fun `Kafka instansen i minnet har blitt startet`() {
-        embeddedEnv.serverPark.status `should equal` KafkaEnvironment.ServerParkStatus.Started
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
     }
 
     fun `Produserer testeventer for alle topics`() {

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/SingleTopicConsumerTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/SingleTopicConsumerTest.kt
@@ -5,16 +5,14 @@ import kotlinx.coroutines.runBlocking
 import no.nav.brukernotifikasjon.schemas.Beskjed
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.common.KafkaEnvironment
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.common.SimpleEventCounterService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.kafka.util.KafkaTestUtil
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.Consumer
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.config.Kafka
-import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.`should equal`
-import org.amshove.kluent.shouldEqualTo
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
@@ -41,7 +39,7 @@ class SingleTopicConsumerTest {
 
     @Test
     fun `Kafka instansen i minnet har blitt startet`() {
-        embeddedEnv.serverPark.status `should equal` KafkaEnvironment.ServerParkStatus.Started
+        embeddedEnv.serverPark.status `should be equal to` KafkaEnvironment.ServerParkStatus.Started
     }
 
     @Test
@@ -66,7 +64,7 @@ class SingleTopicConsumerTest {
     fun `Produserer noen testeventer`() {
         runBlocking {
             KafkaTestUtil.produceEvents(testEnvironment, topicen, events)
-        } shouldEqualTo true
+        } `should be equal to` true
     }
 
     private suspend fun `Vent til alle eventer har blitt konsumert`(eventProcessor: SimpleEventCounterService<Beskjed>) {

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/innboksQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/innboksQueriesTest.kt
@@ -5,7 +5,7 @@ import no.nav.personbruker.dittnav.eventaggregator.common.database.H2Database
 import no.nav.personbruker.dittnav.eventaggregator.done.DoneObjectMother
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain all`
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should not contain`
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
@@ -72,7 +72,7 @@ class innboksQueriesTest {
         runBlocking {
             database.dbQuery {
                 val result = getInnboksById(innboks1.id!!)
-                result `should equal` innboks1
+                result `should be equal to` innboks1
             }
         }
     }
@@ -129,7 +129,7 @@ class innboksQueriesTest {
         runBlocking {
             database.dbQuery {
                 val result = getInnboksByEventId(innboks1.eventId)
-                result `should equal` innboks1
+                result `should be equal to` innboks1
             }
         }
     }
@@ -159,8 +159,8 @@ class innboksQueriesTest {
             val innboks1FraDb = database.dbQuery { getInnboksByEventId(innboks1.eventId) }
             val innboks2FraDb = database.dbQuery { getInnboksByEventId(innboks2.eventId) }
 
-            innboks1FraDb.eventId `should equal` innboks1.eventId
-            innboks2FraDb.eventId `should equal` innboks2.eventId
+            innboks1FraDb.eventId `should be equal to` innboks1.eventId
+            innboks2FraDb.eventId `should be equal to` innboks2.eventId
 
             database.dbQuery { deleteInnboksWithEventId(innboks1.eventId) }
             database.dbQuery { deleteInnboksWithEventId(innboks2.eventId) }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/oppgaveQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/oppgaveQueriesTest.kt
@@ -93,7 +93,7 @@ class oppgaveQueriesTest {
     fun `Finner cachet Oppgave-event for Id`() {
         runBlocking {
             val result = database.dbQuery { oppgave2.id?.let { getOppgaveById(it) } }
-            result `should equal` oppgave2
+            result `should be equal to` oppgave2
         }
     }
 
@@ -110,7 +110,7 @@ class oppgaveQueriesTest {
     fun `Finner cachet Oppgave-event med eventId`() {
         runBlocking {
             val result = database.dbQuery { getOppgaveByEventId(eventId) }
-            result `should equal` oppgave2
+            result `should be equal to` oppgave2
         }
     }
 
@@ -148,8 +148,8 @@ class oppgaveQueriesTest {
             val oppgave1FraDb = database.dbQuery { getOppgaveByEventId(oppgave1.eventId) }
             val oppgave2FraDb = database.dbQuery { getOppgaveByEventId(oppgave2.eventId) }
 
-            oppgave1FraDb.eventId `should equal` oppgave1.eventId
-            oppgave2FraDb.eventId `should equal` oppgave2.eventId
+            oppgave1FraDb.eventId `should be equal to` oppgave1.eventId
+            oppgave2FraDb.eventId `should be equal to` oppgave2.eventId
 
             database.dbQuery { deleteOppgaveWithEventId(oppgave1.eventId) }
             database.dbQuery { deleteOppgaveWithEventId(oppgave2.eventId) }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringQueriesTest.kt
@@ -65,7 +65,7 @@ class StatusoppdateringQueriesTest {
     fun `Finner cachet Statusoppdatering-event med Id`() {
         runBlocking {
             val result = database.dbQuery { statusoppdatering2.id?.let { getStatusoppdateringById(it) } }
-            result `should equal` statusoppdatering2
+            result `should be equal to` statusoppdatering2
         }
     }
 
@@ -99,7 +99,7 @@ class StatusoppdateringQueriesTest {
     fun `Finner cachet Statusoppdatering-event med eventId`() {
         runBlocking {
             val result = database.dbQuery { getStatusoppdateringByEventId(eventId) }
-            result `should equal` statusoppdatering2
+            result `should be equal to` statusoppdatering2
         }
     }
 
@@ -125,8 +125,8 @@ class StatusoppdateringQueriesTest {
             val statusoppdatering1FraDb = database.dbQuery { getStatusoppdateringByEventId(statusoppdatering1.eventId) }
             val statusoppdatering2FraDb = database.dbQuery { getStatusoppdateringByEventId(statusoppdatering2.eventId) }
 
-            statusoppdatering1FraDb.eventId `should equal` statusoppdatering1.eventId
-            statusoppdatering2FraDb.eventId `should equal` statusoppdatering2.eventId
+            statusoppdatering1FraDb.eventId `should be equal to` statusoppdatering1.eventId
+            statusoppdatering2FraDb.eventId `should be equal to` statusoppdatering2.eventId
 
             database.dbQuery { deleteStatusoppdateringWithEventId(statusoppdatering1.eventId) }
             database.dbQuery { deleteStatusoppdateringWithEventId(statusoppdatering2.eventId) }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringTeardownQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringTeardownQueriesTest.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.statusoppdatering
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventaggregator.common.database.H2Database
 import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
 class StatusoppdateringTeardownQueriesTest {
@@ -23,7 +23,7 @@ class StatusoppdateringTeardownQueriesTest {
 
             `Slett alle statusoppdateringelementer fra databasen`()
             val skalIkkeHaElementerIDatabasen = database.dbQuery { getAllStatusoppdatering() }
-            skalIkkeHaElementerIDatabasen.isEmpty() `should equal` true
+            skalIkkeHaElementerIDatabasen.isEmpty() `should be equal to` true
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTest.kt
@@ -12,7 +12,7 @@ import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.Unretriable
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.objectmother.ConsumerRecordsObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.health.Status
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.errors.DisconnectException
 import org.apache.kafka.common.errors.TopicAuthorizationException
@@ -54,7 +54,7 @@ class ConsumerTest {
             consumer.startPolling()
             delay(300)
 
-            consumer.status().status `should equal` Status.OK
+            consumer.status().status `should be equal to` Status.OK
             consumer.stopPolling()
         }
         verify(atLeast = 1) { kafkaConsumer.commitSync() }
@@ -71,7 +71,7 @@ class ConsumerTest {
         runBlocking {
             consumer.startPolling()
             consumer.job.join()
-            consumer.status().status `should equal` Status.ERROR
+            consumer.status().status `should be equal to` Status.ERROR
         }
         verify(exactly = 0) { kafkaConsumer.commitSync() }
     }
@@ -87,7 +87,7 @@ class ConsumerTest {
         runBlocking {
             consumer.startPolling()
             consumer.job.join()
-            consumer.status().status `should equal` Status.ERROR
+            consumer.status().status `should be equal to` Status.ERROR
         }
         verify(exactly = 0) { kafkaConsumer.commitSync() }
     }
@@ -103,7 +103,7 @@ class ConsumerTest {
         runBlocking {
             consumer.startPolling()
             consumer.job.join()
-            consumer.status().status `should equal` Status.ERROR
+            consumer.status().status `should be equal to` Status.ERROR
         }
         verify(exactly = 0) { kafkaConsumer.commitSync() }
     }
@@ -120,7 +120,7 @@ class ConsumerTest {
             consumer.startPolling()
             `Vent litt for aa bevise at det IKKE fortsettes aa polle`()
 
-            consumer.status().status `should equal` Status.OK
+            consumer.status().status `should be equal to` Status.OK
             consumer.stopPolling()
         }
         verify(exactly = 0) { kafkaConsumer.commitSync() }
@@ -141,7 +141,7 @@ class ConsumerTest {
             consumer.startPolling()
             `Vent litt for aa bevise at det IKKE fortsettes aa polle`()
 
-            consumer.status().status `should equal` Status.OK
+            consumer.status().status `should be equal to` Status.OK
             consumer.stopPolling()
         }
         verify(exactly = 0) { kafkaConsumer.commitSync() }
@@ -158,7 +158,7 @@ class ConsumerTest {
         runBlocking {
             consumer.startPolling()
 
-            consumer.status().status `should equal` Status.OK
+            consumer.status().status `should be equal to` Status.OK
             consumer.stopPolling()
         }
         verify(exactly = 0) { kafkaConsumer.commitSync() }
@@ -186,7 +186,7 @@ class ConsumerTest {
 
         runBlocking {
             consumer.startPolling()
-            consumer.status().status `should equal` Status.OK
+            consumer.status().status `should be equal to` Status.OK
             consumer.stopPolling()
         }
         verify(exactly = 0) { kafkaConsumer.commitSync() }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/serializer/SwallowSerializationErrorsAvroDeserializerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/serializer/SwallowSerializationErrorsAvroDeserializerTest.kt
@@ -4,9 +4,10 @@ import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import io.confluent.kafka.serializers.KafkaAvroSerializer
+import no.nav.brukernotifikasjon.schemas.Beskjed
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
 import org.amshove.kluent.`should be null`
-import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
 class SwallowSerializationErrorsAvroDeserializerTest {
@@ -30,9 +31,9 @@ class SwallowSerializationErrorsAvroDeserializerTest {
     fun `should serialize valid records successfully`() {
         val original = AvroBeskjedObjectMother.createBeskjed(1)
         val serialized = serializer.serialize(topic, original)
-        val deserialized = deserializer.deserialize(topic, serialized)
+        val deserialized : Beskjed = deserializer.deserialize(topic, serialized) as Beskjed
 
-        deserialized shouldEqual original
+        deserialized `should be equal to` original
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedLoggingEventTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/logging/MaskedLoggingEventTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.logging
 
 import org.amshove.kluent.`should contain`
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 
@@ -19,23 +19,23 @@ class MaskedLoggingEventTest {
 
     @Test
     fun `sjekk at data som ikke er fodselsnummer ikke blir blir maskert`() {
-        "".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
-        "abc".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
-        "1234".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
-        "1234567890".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
-        "123456789012".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
-        "callId=7b7c12345676543c8c32129c837808f7".let { MaskedLoggingEvent.mask(it)!! `should equal` it }
+        "".let { MaskedLoggingEvent.mask(it)!! `should be equal to` it }
+        "abc".let { MaskedLoggingEvent.mask(it)!! `should be equal to` it }
+        "1234".let { MaskedLoggingEvent.mask(it)!! `should be equal to` it }
+        "1234567890".let { MaskedLoggingEvent.mask(it)!! `should be equal to` it }
+        "123456789012".let { MaskedLoggingEvent.mask(it)!! `should be equal to` it }
+        "callId=7b7c12345676543c8c32129c837808f7".let { MaskedLoggingEvent.mask(it)!! `should be equal to` it }
     }
 
     @Test
     fun `sjekk at maskering av null blir null`() {
-        MaskedLoggingEvent.mask(null) `should equal` null
+        MaskedLoggingEvent.mask(null) `should be equal to` null
     }
 
     @Test
     fun `sjekk at maskert data formatteres riktig`() {
-        MaskedLoggingEvent.mask("12345678901-12345678901 12345678901")!! `should equal` "$MASKED_FNR-$MASKED_FNR $MASKED_FNR"
-        MaskedLoggingEvent.mask("12345678901,12345678901")!! `should equal` "$MASKED_FNR,$MASKED_FNR"
+        MaskedLoggingEvent.mask("12345678901-12345678901 12345678901")!! `should be equal to` "$MASKED_FNR-$MASKED_FNR $MASKED_FNR"
+        MaskedLoggingEvent.mask("12345678901,12345678901")!! `should be equal to` "$MASKED_FNR,$MASKED_FNR"
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/DBMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/DBMetricsProbeTest.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
 import no.nav.personbruker.dittnav.eventaggregator.metrics.db.DBMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.DB_EVENTS_CACHED
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -43,7 +43,7 @@ class DBMetricsProbeTest {
         coVerify(exactly = 1) { metricsReporter.registerDataPoint(DB_EVENTS_CACHED, any(), any()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsCached(any(), any(), any()) }
 
-        producerNameForPrometheus.captured `should equal` producerAlias
+        producerNameForPrometheus.captured `should be equal to` producerAlias
     }
 
     @Test
@@ -67,6 +67,6 @@ class DBMetricsProbeTest {
                 listOf("eventType" to EventType.DONE.toString(), "producer" to "test-user").toMap()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsCached(2, EventType.DONE, "test-user") }
 
-        capturedFieldsForCachedEvents.captured["counter"] `should equal` 2
+        capturedFieldsForCachedEvents.captured["counter"] `should be equal to` 2
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/EventMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/EventMetricsProbeTest.kt
@@ -7,7 +7,7 @@ import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.KAFKA_EVENTS_B
 import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.KAFKA_EVENTS_FAILED
 import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.KAFKA_EVENTS_PROCESSED
 import no.nav.personbruker.dittnav.eventaggregator.metrics.influx.KAFKA_EVENTS_SEEN
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -48,8 +48,8 @@ internal class EventMetricsProbeTest {
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsSeen(any(), any(), any()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsProcessed(any(), any(), any()) }
 
-        producerNameForPrometheus.captured `should equal` producerAlias
-        capturedTags.captured["producer"] `should equal` producerAlias
+        producerNameForPrometheus.captured `should be equal to` producerAlias
+        capturedTags.captured["producer"] `should be equal to` producerAlias
     }
 
     @Test
@@ -78,8 +78,8 @@ internal class EventMetricsProbeTest {
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsSeen(any(), any(), any()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsFailed(any(), any(), any()) }
 
-        producerNameForPrometheus.captured `should equal` producerAlias
-        capturedTags.captured["producer"] `should equal` producerAlias
+        producerNameForPrometheus.captured `should be equal to` producerAlias
+        capturedTags.captured["producer"] `should be equal to` producerAlias
     }
 
     @Test
@@ -110,8 +110,8 @@ internal class EventMetricsProbeTest {
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsProcessed(2, any(), any()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerEventsFailed(1, any(), any()) }
 
-        capturedFieldsForSeen.captured["counter"] `should equal` 3
-        capturedFieldsForProcessed.captured["counter"] `should equal` 2
-        capturedFieldsForFailed.captured["counter"] `should equal` 1
+        capturedFieldsForSeen.captured["counter"] `should be equal to` 3
+        capturedFieldsForProcessed.captured["counter"] `should be equal to` 2
+        capturedFieldsForFailed.captured["counter"] `should be equal to` 1
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/ProducerNameResolverTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/ProducerNameResolverTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.metrics.db.Produsent
 import org.amshove.kluent.`should be null`
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,7 +36,7 @@ internal class ProducerNameResolverTest {
     fun `skal returnere produsentnavn`() {
         runBlocking {
             val producerNameAlias = producerNameResolver.getProducerNameAlias("x-dittnav")
-            producerNameAlias `should equal` "dittnav"
+            producerNameAlias `should be equal to` "dittnav"
         }
     }
 
@@ -50,7 +50,7 @@ internal class ProducerNameResolverTest {
             }.throws(SQLException())
 
             val newProducerNameAlias = producerNameResolver.getProducerNameAlias("x-dittnav")
-            originalProducerNameAlias `should equal` newProducerNameAlias
+            originalProducerNameAlias `should be equal to` newProducerNameAlias
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/ProducerNameScrubberTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/ProducerNameScrubberTest.kt
@@ -3,8 +3,8 @@ package no.nav.personbruker.dittnav.eventaggregator.metrics
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import org.amshove.kluent.`should equal`
-import org.amshove.kluent.`should not equal`
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should not be equal to`
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
@@ -25,8 +25,8 @@ internal class ProducerNameScrubberTest {
         runBlocking {
             val scrubbedName = nameScrubber.getPublicAlias(systemUser)
 
-            scrubbedName `should equal` producerNameAlias
-            scrubbedName `should not equal` systemUser
+            scrubbedName `should be equal to` producerNameAlias
+            scrubbedName `should not be equal to` systemUser
         }
     }
 
@@ -37,8 +37,8 @@ internal class ProducerNameScrubberTest {
         runBlocking {
             val scrubbedName = nameScrubber.getPublicAlias(unknownSystemUser)
 
-            scrubbedName `should equal` nameScrubber.GENERIC_SYSTEM_USER
-            scrubbedName `should not equal` systemUser
+            scrubbedName `should be equal to` nameScrubber.GENERIC_SYSTEM_USER
+            scrubbedName `should not be equal to` systemUser
         }
     }
 
@@ -49,8 +49,8 @@ internal class ProducerNameScrubberTest {
         runBlocking {
             val scrubbedName = nameScrubber.getPublicAlias(unknownSystemUser)
 
-            scrubbedName `should equal` nameScrubber.UNKNOWN_USER
-            scrubbedName `should not equal` systemUser
+            scrubbedName `should be equal to` nameScrubber.UNKNOWN_USER
+            scrubbedName `should not be equal to` systemUser
         }
     }
 }


### PR DESCRIPTION
Oppgradert til ny versjon av `dittnav-dependencies`, som inneholder ny versjon av Kluent.

Fjernet alle nye warnings som kom til pga at enkelte metoder i Kluent hadde blitt deprecated.