### PR TITLE
Oppgradert til nye versjon av `Mockk`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2020.10.07-12.16-dae8cb1e56ed"
+val dittNavDependenciesVersion = "2020.10.07-12.37-4d2b8b1e2521"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")


### PR DESCRIPTION
Oppgradert til ny versjon av `dittnav-dependencies`, som inneholder ny versjon av `Mockk`.

Har oppgradert til det som på Github er marker som siste release-versjon av Mockk. Det finnes to nyere tags, men ved bruk av disse er det flere av våre tester som ikke fungerer slik de skal.