### PR TITLE
Periodisk sjekk som ser om alle kafka-konsumerne kjører

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
@@ -44,6 +44,10 @@ class Consumer<T>(
         return job.isCompleted
     }
 
+    fun isStopped(): Boolean {
+        return !job.isActive
+    }
+
     override suspend fun status(): HealthStatus {
         val serviceName = topic + "consumer"
         return if (job.isActive) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
@@ -8,7 +8,7 @@ import io.ktor.features.DefaultHeaders
 import io.ktor.routing.routing
 import io.prometheus.client.hotspot.DefaultExports
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.kafka.pollingApi
+import no.nav.personbruker.dittnav.eventaggregator.polling.pollingApi
 import no.nav.personbruker.dittnav.eventaggregator.done.waitTableApi
 import no.nav.personbruker.dittnav.eventaggregator.health.healthApi
 
@@ -30,6 +30,7 @@ private fun Application.configureStartupHook(appContext: ApplicationContext) {
         Flyway.runFlywayMigrations(appContext.environment)
         KafkaConsumerSetup.startAllKafkaPollers(appContext)
         appContext.periodicDoneEventWaitingTableProcessor.start()
+        appContext.periodicConsumerChecker.start()
     }
 }
 
@@ -38,6 +39,7 @@ private fun Application.configureShutdownHook(appContext: ApplicationContext) {
         runBlocking {
             KafkaConsumerSetup.stopAllKafkaConsumers(appContext)
             appContext.periodicDoneEventWaitingTableProcessor.stop()
+            appContext.periodicConsumerChecker.stop()
         }
         appContext.database.dataSource.close()
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/bootstrap.kt
@@ -28,6 +28,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
 private fun Application.configureStartupHook(appContext: ApplicationContext) {
     environment.monitor.subscribe(ApplicationStarted) {
         Flyway.runFlywayMigrations(appContext.environment)
+        KafkaConsumerSetup.startAllKafkaPollers(appContext)
         appContext.periodicDoneEventWaitingTableProcessor.start()
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/health/HealthService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/health/HealthService.kt
@@ -12,7 +12,8 @@ class HealthService(private val applicationContext: ApplicationContext) {
                 applicationContext.oppgaveConsumer.status(),
                 applicationContext.doneConsumer.status(),
                 applicationContext.statusoppdateringConsumer.status(),
-                applicationContext.periodicDoneEventWaitingTableProcessor.status()
+                applicationContext.periodicDoneEventWaitingTableProcessor.status(),
+                applicationContext.periodicConsumerChecker.status()
         )
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/polling/PeriodicDoneEventWaitingTableProcessor.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/polling/PeriodicDoneEventWaitingTableProcessor.kt
@@ -1,0 +1,70 @@
+package no.nav.personbruker.dittnav.eventaggregator.polling
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.time.delay
+import no.nav.personbruker.dittnav.eventaggregator.config.ApplicationContext
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.health.HealthStatus
+import no.nav.personbruker.dittnav.eventaggregator.health.Status
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import kotlin.coroutines.CoroutineContext
+
+class PeriodicConsumerChecker(
+    private val appContext: ApplicationContext,
+    private val job: Job = Job()
+) : CoroutineScope {
+
+    private val log: Logger = LoggerFactory.getLogger(PeriodicConsumerChecker::class.java)
+    private val minutesToWait = Duration.ofMinutes(30)
+
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Default + job
+
+    fun status(): HealthStatus {
+        return when (job.isActive) {
+            true -> HealthStatus("PeriodicConsumerChecker", Status.OK, "Checker is running", false)
+            false -> HealthStatus("PeriodicConsumerChecker", Status.ERROR, "Checker is not running", false)
+        }
+    }
+
+    suspend fun stop() {
+        log.info("Stopper periodisk sjekking av at konsumerne kjører")
+        job.cancelAndJoin()
+    }
+
+    fun isCompleted(): Boolean {
+        return job.isCompleted
+    }
+
+    fun start() {
+        log.info("Periodisk sjekking av at konsumerne kjører har blitt aktivert, første sjekk skjer om $minutesToWait minutter.")
+        launch {
+            while (job.isActive) {
+                delay(minutesToWait)
+                checkIfConsumersAreRunningAndRestartIfNot()
+            }
+        }
+    }
+
+    private suspend fun checkIfConsumersAreRunningAndRestartIfNot() {
+        val stoppedConsumers = mutableListOf<EventType>()
+        if(appContext.beskjedConsumer.isStopped()) {
+            stoppedConsumers.add(EventType.BESKJED)
+        }
+        if(appContext.doneConsumer.isStopped()) {
+            stoppedConsumers.add(EventType.DONE)
+        }
+        if(appContext.oppgaveConsumer.isStopped()) {
+            stoppedConsumers.add(EventType.OPPGAVE)
+        }
+
+        if (stoppedConsumers.isNotEmpty()) {
+            log.warn("Følgende konsumere hadde stoppet $stoppedConsumers, de(n) vil bli restartet.")
+            appContext.restartPolling()
+            log.info("Konsumerne har blitt restartet.")
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/polling/pollingApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/polling/pollingApi.kt
@@ -1,4 +1,4 @@
-package no.nav.personbruker.dittnav.eventaggregator.common.kafka
+package no.nav.personbruker.dittnav.eventaggregator.polling
 
 import io.ktor.application.call
 import io.ktor.http.ContentType
@@ -12,7 +12,7 @@ fun Routing.pollingApi(appContext: ApplicationContext) {
 
     get("/internal/polling/start") {
         val responseText = "Polling etter eventer har blitt startet."
-        restartPolling(appContext)
+        appContext.restartPolling()
         call.respondText(text = responseText, contentType = ContentType.Text.Plain)
     }
 
@@ -21,10 +21,18 @@ fun Routing.pollingApi(appContext: ApplicationContext) {
         KafkaConsumerSetup.stopAllKafkaConsumers(appContext)
         call.respondText(text = responseText, contentType = ContentType.Text.Plain)
     }
-}
 
-private suspend fun restartPolling(appContext: ApplicationContext) {
-    KafkaConsumerSetup.stopAllKafkaConsumers(appContext)
-    appContext.reinitializeConsumers()
-    KafkaConsumerSetup.startAllKafkaPollers(appContext)
+    get("/internal/polling/checker/start") {
+        val responseText = "Startee jobben som sjekker om konsumerne kjører."
+        appContext.reinitializePeriodicConsumerChecker()
+        appContext.periodicConsumerChecker.start()
+        call.respondText(text = responseText, contentType = ContentType.Text.Plain)
+    }
+
+    get("/internal/polling/checker/stop") {
+        val responseText = "Stoppet jobben som sjekker om konsumerne kjører."
+        appContext.periodicConsumerChecker.stop()
+        call.respondText(text = responseText, contentType = ContentType.Text.Plain)
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/polling/pollingApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/polling/pollingApi.kt
@@ -23,7 +23,7 @@ fun Routing.pollingApi(appContext: ApplicationContext) {
     }
 
     get("/internal/polling/checker/start") {
-        val responseText = "Startee jobben som sjekker om konsumerne kjører."
+        val responseText = "Startet jobben som sjekker om konsumerne kjører."
         appContext.reinitializePeriodicConsumerChecker()
         appContext.periodicConsumerChecker.start()
         call.respondText(text = responseText, contentType = ContentType.Text.Plain)


### PR DESCRIPTION
Dette er en rask og naiv implementasjon av denne featuren, og har ikke all funksjonalitet som vi ønsker på sikt.

Hvis det blir funnet at minst en konsumer ikke kjører, så restartes de. Gjenbruker samme logikk som om konsumerne hadde blitt restartet manuelt via REST.

Sjekken kjøres hvert 30. minutt, etter at appen har blitt startet.

Har i tillegg reaktivert at det polles etter eventer med en gang appen starter.