### PR TITLE
Valider alle event som kommer inn fra Kafka med brukernotifikasjon-schemas

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ val intTestImplementation by configurations.getting {
 configurations["intTestRuntimeOnly"].extendsFrom(configurations.testRuntimeOnly.get())
 
 dependencies {
-    implementation(Brukernotifikasjon.schemas)
+    implementation("com.github.navikt:brukernotifikasjon-schemas:test-builder-eksternvarsling_v4")
     implementation(DittNAV.Common.utils)
     implementation(Flyway.core)
     implementation(Hikari.cp)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ val intTestImplementation by configurations.getting {
 configurations["intTestRuntimeOnly"].extendsFrom(configurations.testRuntimeOnly.get())
 
 dependencies {
-    implementation("com.github.navikt:brukernotifikasjon-schemas:test-builder-eksternvarsling_v5")
+    implementation(Brukernotifikasjon.schemas)
     implementation(DittNAV.Common.utils)
     implementation(Flyway.core)
     implementation(Hikari.cp)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ val intTestImplementation by configurations.getting {
 configurations["intTestRuntimeOnly"].extendsFrom(configurations.testRuntimeOnly.get())
 
 dependencies {
-    implementation("com.github.navikt:brukernotifikasjon-schemas:test-builder-eksternvarsling_v4")
+    implementation("com.github.navikt:brukernotifikasjon-schemas:test-builder-eksternvarsling_v5")
     implementation(DittNAV.Common.utils)
     implementation(Flyway.core)
     implementation(Hikari.cp)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
@@ -1,8 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateMaxLength
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullFieldMaxLength
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateSikkerhetsnivaa
+import no.nav.brukernotifikasjon.schemas.builders.domain.Eventtype
+import no.nav.brukernotifikasjon.schemas.builders.util.ValidationUtil
 import java.time.LocalDateTime
 
 data class Beskjed(
@@ -49,14 +48,15 @@ data class Beskjed(
             aktiv,
             eksternVarsling
     ) {
-        validateNonNullFieldMaxLength(systembruker, "systembruker", 100)
-        validateNonNullFieldMaxLength(eventId, "eventId", 50)
-        validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
-        validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)
-        validateNonNullFieldMaxLength(tekst, "tekst", 300)
-        validateMaxLength(link, "link", 200)
-        validateSikkerhetsnivaa(sikkerhetsnivaa)
-        validateNonNullFieldMaxLength(uid, "uid", 100)
+        ValidationUtil.validateNonNullFieldMaxLength(systembruker, "systembruker", ValidationUtil.MAX_LENGTH_SYSTEMBRUKER)
+        ValidationUtil.validateNonNullFieldMaxLength(eventId, "eventId", ValidationUtil.MAX_LENGTH_EVENTID)
+        ValidationUtil.validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", ValidationUtil.MAX_LENGTH_FODSELSNUMMER)
+        ValidationUtil.validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", ValidationUtil.MAX_LENGTH_GRUPPERINGSID)
+        ValidationUtil.validateNonNullFieldMaxLength(tekst, "tekst", ValidationUtil.MAX_LENGTH_TEXT_BESKJED)
+        ValidationUtil.validateLinkAndConvertToString(ValidationUtil.validateLinkAndConvertToURL(link), "link", ValidationUtil.MAX_LENGTH_LINK, ValidationUtil.isLinkRequired(Eventtype.BESKJED))
+        ValidationUtil.validateSikkerhetsnivaa(sikkerhetsnivaa)
+        ValidationUtil.validateNonNullFieldMaxLength(uid, "uid", ValidationUtil.MAX_LENGTH_UID)
+        ValidationUtil.validateEksternvarsling(eksternVarsling)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/Beskjed.kt
@@ -56,7 +56,6 @@ data class Beskjed(
         ValidationUtil.validateLinkAndConvertToString(ValidationUtil.validateLinkAndConvertToURL(link), "link", ValidationUtil.MAX_LENGTH_LINK, ValidationUtil.isLinkRequired(Eventtype.BESKJED))
         ValidationUtil.validateSikkerhetsnivaa(sikkerhetsnivaa)
         ValidationUtil.validateNonNullFieldMaxLength(uid, "uid", ValidationUtil.MAX_LENGTH_UID)
-        ValidationUtil.validateEksternvarsling(eksternVarsling)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
@@ -2,10 +2,10 @@ package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
 import no.nav.brukernotifikasjon.schemas.Beskjed
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.BrukernotifikasjonPersistingService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullKey

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/FieldValidationException.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/FieldValidationException.kt
@@ -1,8 +1,0 @@
-package no.nav.personbruker.dittnav.eventaggregator.common.exceptions
-
-/*
-open class FieldValidationException (message: String, cause: Throwable?) : AbstractPersonbrukerException(message, cause) {
-    constructor(message: String) : this(message, null)
-}
-
- */

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/FieldValidationException.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/exceptions/FieldValidationException.kt
@@ -1,5 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.exceptions
 
+/*
 open class FieldValidationException (message: String, cause: Throwable?) : AbstractPersonbrukerException(message, cause) {
     constructor(message: String) : this(message, null)
 }
+
+ */

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/validation/validationUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/validation/validationUtil.kt
@@ -1,63 +1,11 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.validation
 
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 
-private val fodselsnummerRegEx = """[\d]{1,11}""".toRegex()
-
-fun validateFodselsnummer(field: String): String {
-    validateNonNullField(field, "fødselsnummer")
-    if (isNotValidFodselsnummer(field)) {
-        val fve = FieldValidationException("Feltet fodselsnummer kan kun innholde siffer, og maks antall er 11.")
-        fve.addContext("rejectedFieldValue", field)
-        throw fve
-    }
-    return field
-}
-
-private fun isNotValidFodselsnummer(field: String) = !fodselsnummerRegEx.matches(field)
-
-fun validateNonNullFieldMaxLength(field: String, fieldName: String, maxLength: Int): String {
-    validateNonNullField(field, fieldName)
-    return validateMaxLength(field, fieldName, maxLength)
-}
-
-fun validateMaxLength(field: String, fieldName: String, maxLength: Int): String {
-    if (field.length > maxLength) {
-        val fve = FieldValidationException("Feltet $fieldName kan ikke inneholde mer enn $maxLength tegn.")
-        fve.addContext("rejectedFieldValueLength", field.length)
-        throw fve
-    }
-    return field
-}
-
-fun validateNonNullField(field: String?, fieldName: String): String {
-    if (field.isNullOrBlank()) {
-        val fve = FieldValidationException("$fieldName var null eller tomt.")
-        fve.addContext("nullOrBlank", fieldName)
-        throw fve
-    }
-    return field
-}
-
 fun timestampToUTCDateOrNull(timestamp: Long?): LocalDateTime? {
     return timestamp?.let { datetime ->
         LocalDateTime.ofInstant(Instant.ofEpochMilli(datetime), ZoneId.of("UTC"))
-    }
-}
-
-fun validateSikkerhetsnivaa(sikkerhetsnivaa: Int): Int {
-    return when (sikkerhetsnivaa) {
-        3, 4 -> sikkerhetsnivaa
-        else -> throw FieldValidationException("Sikkerhetsnivaa kan bare være 3 eller 4.")
-    }
-}
-
-fun validateStatusGlobal(statusGlobal: String): String {
-    return when (statusGlobal) {
-        "SENDT", "MOTTATT", "UNDER_BEHANDLING", "FERDIG" -> statusGlobal
-        else -> throw FieldValidationException("StatusGlobal kan kun inneholde SENDT, MOTTATT, UNDER_BEHANDLING eller FERDIG.")
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/Done.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/Done.kt
@@ -1,7 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateFodselsnummer
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullFieldMaxLength
+import no.nav.brukernotifikasjon.schemas.builders.util.ValidationUtil
 import java.time.LocalDateTime
 
 data class Done(
@@ -13,9 +12,9 @@ data class Done(
 ) {
 
     init {
-        validateNonNullFieldMaxLength(systembruker, "systembruker", 100)
-        validateNonNullFieldMaxLength(eventId, "eventId", 50)
-        validateFodselsnummer(fodselsnummer)
+        ValidationUtil.validateNonNullFieldMaxLength(systembruker, "systembruker", ValidationUtil.MAX_LENGTH_SYSTEMBRUKER)
+        ValidationUtil.validateNonNullFieldMaxLength(eventId, "eventId", ValidationUtil.MAX_LENGTH_EVENTID)
+        ValidationUtil.validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", ValidationUtil.MAX_LENGTH_FODSELSNUMMER)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
@@ -2,9 +2,9 @@ package no.nav.personbruker.dittnav.eventaggregator.done
 
 import no.nav.brukernotifikasjon.schemas.Done
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullKey
@@ -52,7 +52,7 @@ class DoneEventService(
             donePersistingService.writeDoneEventsForBeskjedToCache(groupedDoneEvents.foundBeskjed)
             donePersistingService.writeDoneEventsForOppgaveToCache(groupedDoneEvents.foundOppgave)
             donePersistingService.writeDoneEventsForInnboksToCache(groupedDoneEvents.foundInnboks)
-            val writeEventsToCacheResult= donePersistingService.writeEventsToCache(groupedDoneEvents.notFoundEvents)
+            val writeEventsToCacheResult = donePersistingService.writeEventsToCache(groupedDoneEvents.notFoundEvents)
             countDuplicateKeyEvents(writeEventsToCacheResult)
         }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/Innboks.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/Innboks.kt
@@ -1,11 +1,10 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateMaxLength
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullFieldMaxLength
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateSikkerhetsnivaa
+import no.nav.brukernotifikasjon.schemas.builders.domain.Eventtype
+import no.nav.brukernotifikasjon.schemas.builders.util.ValidationUtil
 import java.time.LocalDateTime
 
-data class Innboks (
+data class Innboks(
         val id: Int?,
         val systembruker: String,
         val eventId: String,
@@ -42,13 +41,13 @@ data class Innboks (
             sistOppdatert,
             aktiv
     ) {
-        validateNonNullFieldMaxLength(systembruker, "systembruker", 100)
-        validateNonNullFieldMaxLength(eventId, "eventId", 50)
-        validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
-        validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)
-        validateNonNullFieldMaxLength(tekst, "tekst", 500)
-        validateMaxLength(link, "link", 200)
-        validateSikkerhetsnivaa(sikkerhetsnivaa)
+        ValidationUtil.validateNonNullFieldMaxLength(systembruker, "systembruker", ValidationUtil.MAX_LENGTH_SYSTEMBRUKER)
+        ValidationUtil.validateNonNullFieldMaxLength(eventId, "eventId", ValidationUtil.MAX_LENGTH_EVENTID)
+        ValidationUtil.validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", ValidationUtil.MAX_LENGTH_FODSELSNUMMER)
+        ValidationUtil.validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", ValidationUtil.MAX_LENGTH_GRUPPERINGSID)
+        ValidationUtil.validateNonNullFieldMaxLength(tekst, "tekst", ValidationUtil.MAX_LENGTH_TEXT_INNBOKS)
+        ValidationUtil.validateLinkAndConvertToString(ValidationUtil.validateLinkAndConvertToURL(link), "link", ValidationUtil.MAX_LENGTH_LINK, ValidationUtil.isLinkRequired(Eventtype.INNBOKS))
+        ValidationUtil.validateSikkerhetsnivaa(sikkerhetsnivaa)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
@@ -2,10 +2,10 @@ package no.nav.personbruker.dittnav.eventaggregator.innboks
 
 import no.nav.brukernotifikasjon.schemas.Innboks
 import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.BrukernotifikasjonPersistingService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullKey

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTransformer.kt
@@ -1,7 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullField
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -15,7 +14,7 @@ object InnboksTransformer {
                 nokkel.getSystembruker(),
                 nokkel.getEventId(),
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(external.getTidspunkt()), ZoneId.of("UTC")),
-                validateNonNullField(external.getFodselsnummer(), "Fødselsnummer"),
+                external.getFodselsnummer(),
                 external.getGrupperingsId(),
                 external.getTekst(),
                 external.getLink(),

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
@@ -50,7 +50,6 @@ data class Oppgave(
         ValidationUtil.validateNonNullFieldMaxLength(tekst, "tekst", ValidationUtil.MAX_LENGTH_TEXT_OPPGAVE)
         ValidationUtil.validateLinkAndConvertToString(ValidationUtil.validateLinkAndConvertToURL(link), "link", ValidationUtil.MAX_LENGTH_LINK, ValidationUtil.isLinkRequired(Eventtype.OPPGAVE))
         ValidationUtil.validateSikkerhetsnivaa(sikkerhetsnivaa)
-        ValidationUtil.validateEksternvarsling(eksternVarsling)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/Oppgave.kt
@@ -1,8 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateMaxLength
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullFieldMaxLength
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateSikkerhetsnivaa
+import no.nav.brukernotifikasjon.schemas.builders.domain.Eventtype
+import no.nav.brukernotifikasjon.schemas.builders.util.ValidationUtil
 import java.time.LocalDateTime
 
 data class Oppgave(
@@ -44,13 +43,14 @@ data class Oppgave(
             aktiv,
             eksternVarsling
     ) {
-        validateNonNullFieldMaxLength(systembruker, "systembruker", 100)
-        validateNonNullFieldMaxLength(eventId, "eventId", 50)
-        validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
-        validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)
-        validateNonNullFieldMaxLength(tekst, "tekst", 500)
-        validateNonNullFieldMaxLength(link, "link", 200)
-        validateSikkerhetsnivaa(sikkerhetsnivaa)
+        ValidationUtil.validateNonNullFieldMaxLength(systembruker, "systembruker", ValidationUtil.MAX_LENGTH_SYSTEMBRUKER)
+        ValidationUtil.validateNonNullFieldMaxLength(eventId, "eventId", ValidationUtil.MAX_LENGTH_EVENTID)
+        ValidationUtil.validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", ValidationUtil.MAX_LENGTH_FODSELSNUMMER)
+        ValidationUtil.validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", ValidationUtil.MAX_LENGTH_GRUPPERINGSID)
+        ValidationUtil.validateNonNullFieldMaxLength(tekst, "tekst", ValidationUtil.MAX_LENGTH_TEXT_OPPGAVE)
+        ValidationUtil.validateLinkAndConvertToString(ValidationUtil.validateLinkAndConvertToURL(link), "link", ValidationUtil.MAX_LENGTH_LINK, ValidationUtil.isLinkRequired(Eventtype.OPPGAVE))
+        ValidationUtil.validateSikkerhetsnivaa(sikkerhetsnivaa)
+        ValidationUtil.validateEksternvarsling(eksternVarsling)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
@@ -2,10 +2,10 @@ package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.brukernotifikasjon.schemas.Oppgave
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.BrukernotifikasjonPersistingService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullKey

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTransformer.kt
@@ -1,7 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullField
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -15,7 +14,7 @@ object OppgaveTransformer {
                 nokkel.getSystembruker(),
                 nokkel.getEventId(),
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(external.getTidspunkt()), ZoneId.of("UTC")),
-                validateNonNullField(external.getFodselsnummer(), "Fødselsnummer"),
+                external.getFodselsnummer(),
                 external.getGrupperingsId(),
                 external.getTekst(),
                 external.getLink(),

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/Statusoppdatering.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/Statusoppdatering.kt
@@ -1,9 +1,9 @@
 package no.nav.personbruker.dittnav.eventaggregator.statusoppdatering
 
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateMaxLength
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateNonNullFieldMaxLength
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateSikkerhetsnivaa
-import no.nav.personbruker.dittnav.eventaggregator.common.validation.validateStatusGlobal
+import no.nav.brukernotifikasjon.schemas.builders.domain.Eventtype
+import no.nav.brukernotifikasjon.schemas.builders.util.ValidationUtil
+import no.nav.brukernotifikasjon.schemas.builders.util.ValidationUtil.MAX_LENGTH_SAKSTEMA
+import no.nav.brukernotifikasjon.schemas.builders.util.ValidationUtil.MAX_LENGTH_STATUSINTERN
 import java.time.LocalDateTime
 
 data class Statusoppdatering(
@@ -46,15 +46,15 @@ data class Statusoppdatering(
             sakstema
 
     ) {
-        validateNonNullFieldMaxLength(systembruker, "systembruker", 100)
-        validateNonNullFieldMaxLength(eventId, "eventId", 50)
-        validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", 11)
-        validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", 100)
-        validateMaxLength(link, "link", 200)
-        validateSikkerhetsnivaa(sikkerhetsnivaa)
-        validateStatusGlobal(statusGlobal)
-        statusIntern?.let { status -> validateMaxLength(status, "statusIntern", 100) }
-        validateNonNullFieldMaxLength(sakstema, "sakstema", 50)
+        ValidationUtil.validateNonNullFieldMaxLength(systembruker, "systembruker", ValidationUtil.MAX_LENGTH_SYSTEMBRUKER)
+        ValidationUtil.validateNonNullFieldMaxLength(eventId, "eventId", ValidationUtil.MAX_LENGTH_EVENTID)
+        ValidationUtil.validateNonNullFieldMaxLength(fodselsnummer, "fodselsnummer", ValidationUtil.MAX_LENGTH_FODSELSNUMMER)
+        ValidationUtil.validateNonNullFieldMaxLength(grupperingsId, "grupperingsId", ValidationUtil.MAX_LENGTH_GRUPPERINGSID)
+        ValidationUtil.validateLinkAndConvertToString(ValidationUtil.validateLinkAndConvertToURL(link), "link", ValidationUtil.MAX_LENGTH_LINK, ValidationUtil.isLinkRequired(Eventtype.STATUSOPPDATERING))
+        ValidationUtil.validateSikkerhetsnivaa(sikkerhetsnivaa)
+        ValidationUtil.validateStatusGlobal(statusGlobal)
+        statusIntern?.let { status -> ValidationUtil.validateMaxLength(status, "statusIntern", MAX_LENGTH_STATUSINTERN) }
+        ValidationUtil.validateNonNullFieldMaxLength(sakstema, "sakstema", MAX_LENGTH_SAKSTEMA)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringEventService.kt
@@ -2,10 +2,10 @@ package no.nav.personbruker.dittnav.eventaggregator.statusoppdatering
 
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.brukernotifikasjon.schemas.Statusoppdatering
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.BrukernotifikasjonPersistingService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.NokkelNullException
 import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.UntransformableRecordException
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.serializer.getNonNullKey

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
@@ -18,14 +18,11 @@ object BeskjedObjectMother {
     }
 
     fun giveMeAktivBeskjed(eventId: String, fodselsnummer: String): Beskjed {
-        val systembruker = "dummySystembruker"
-        val link = "https://nav.no/systemX/$eventId"
-        return giveMeAktivBeskjed(eventId, fodselsnummer, systembruker, link)
+        return giveMeAktivBeskjed(eventId = eventId, fodselsnummer = fodselsnummer, systembruker = "dummySystembruker", link = "https://nav.no/systemX/$eventId")
     }
 
     fun giveMeAktivBeskjed(eventId: String, fodselsnummer: String, systembruker: String): Beskjed {
-        val link = "https://nav.no/systemX/$eventId"
-        return giveMeAktivBeskjed(eventId, fodselsnummer, systembruker, link)
+        return giveMeAktivBeskjed(eventId = eventId, fodselsnummer = fodselsnummer, systembruker =  systembruker, link = "https://nav.no/systemX/$eventId")
     }
 
     fun giveMeAktivBeskjedWithLink(link: String): Beskjed {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
@@ -19,10 +19,20 @@ object BeskjedObjectMother {
 
     fun giveMeAktivBeskjed(eventId: String, fodselsnummer: String): Beskjed {
         val systembruker = "dummySystembruker"
-        return giveMeAktivBeskjed(eventId, fodselsnummer, systembruker)
+        val link = "https://nav.no/systemX/$eventId"
+        return giveMeAktivBeskjed(eventId, fodselsnummer, systembruker, link)
     }
 
     fun giveMeAktivBeskjed(eventId: String, fodselsnummer: String, systembruker: String): Beskjed {
+        val link = "https://nav.no/systemX/$eventId"
+        return giveMeAktivBeskjed(eventId, fodselsnummer, systembruker, link)
+    }
+
+    fun giveMeAktivBeskjedWithLink(link: String): Beskjed {
+        return giveMeAktivBeskjed(eventId = "B-2", fodselsnummer = "1234", systembruker = "dummySystembruker", link = link)
+    }
+
+    fun giveMeAktivBeskjed(eventId: String, fodselsnummer: String, systembruker: String, link: String): Beskjed {
         return Beskjed(
                 uid = Random.nextInt(1, 100).toString(),
                 systembruker = systembruker,
@@ -32,7 +42,7 @@ object BeskjedObjectMother {
                 eventId = eventId,
                 grupperingsId = "systemA010",
                 tekst = "Dette er beskjed til brukeren",
-                link = "https://nav.no/systemX/$eventId",
+                link = link,
                 sistOppdatert = LocalDateTime.now(ZoneId.of("UTC")),
                 sikkerhetsnivaa = 4,
                 aktiv = true,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTest.kt
@@ -1,7 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.`with message containing`
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.amshove.kluent.`should throw`
 import org.amshove.kluent.invoking
@@ -140,7 +141,7 @@ class BeskjedTest {
 
     @Test
     fun `do not allow too long link`() {
-        val tooLongLink = "L".repeat(201)
+        val tooLongLink = "http://" + "L".repeat(201)
         invoking {
             Beskjed(
                     uid = uid,
@@ -157,6 +158,33 @@ class BeskjedTest {
                     aktiv = true,
                     eksternVarsling = false)
         } `should throw` FieldValidationException::class `with message containing` "link"
+    }
+
+    @Test
+    fun `do not allow invalid link`() {
+        val invalidLink = "invalidUrl"
+        invoking {
+            Beskjed(
+                    uid = uid,
+                    systembruker = validSystembruker,
+                    eventTidspunkt = eventTidspunkt,
+                    synligFremTil = synligFremTil,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = invalidLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true,
+                    eksternVarsling = false)
+        } `should throw` FieldValidationException::class `with message containing` "link"
+    }
+
+    @Test
+    fun `should allow empty link`() {
+        val beskjed = BeskjedObjectMother.giveMeAktivBeskjedWithLink("")
+        beskjed.link `should be equal to` ""
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTransformerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.*
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTransformerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.done.schema.AvroDoneObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.`should be equal to`

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksObjectMother.kt
@@ -10,10 +10,18 @@ object InnboksObjectMother {
     }
 
     fun giveMeAktivInnboks(eventId: String, fodselsnummer: String): Innboks {
-        return giveMeAktivInnboks(eventId, fodselsnummer, "dummySystembruker")
+        return giveMeAktivInnboks(eventId = eventId, fodselsnummer = fodselsnummer, "dummySystembruker", "https://nav.no/systemX/")
     }
 
     fun giveMeAktivInnboks(eventId: String, fodselsnummer: String, systembruker: String): Innboks {
+        return giveMeAktivInnboks(eventId = eventId, fodselsnummer = fodselsnummer, systembruker = systembruker, link = "https://nav.no/systemX/")
+    }
+
+    fun giveMeAktivInnboksWithLink(link: String): Innboks {
+        return giveMeAktivInnboks(eventId = "i-2", fodselsnummer = "123", systembruker = "dummySystembruker", link = link)
+    }
+
+    fun giveMeAktivInnboks(eventId: String, fodselsnummer: String, systembruker: String, link: String): Innboks {
         return Innboks(
                 systembruker,
                 eventId,
@@ -21,7 +29,7 @@ object InnboksObjectMother {
                 fodselsnummer,
                 "76543",
                 "Dette er innboksnotifikasjon til brukeren",
-                "https://nav.no/systemX/",
+                link,
                 4,
                 LocalDateTime.now(ZoneId.of("UTC")),
                 true)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTest.kt
@@ -1,7 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.`with message containing`
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.amshove.kluent.`should throw`
 import org.amshove.kluent.invoking
@@ -124,7 +125,7 @@ class InnboksTest {
 
     @Test
     fun `do not allow too long link`() {
-        val tooLongLink = "L".repeat(201)
+        val tooLongLink = "http://" + "L".repeat(201)
         invoking {
             Innboks(
 
@@ -139,6 +140,31 @@ class InnboksTest {
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true)
         } `should throw` FieldValidationException::class `with message containing` "link"
+    }
+
+    @Test
+    fun `do not allow invalid link`() {
+        val invalidLink = "invalidUrl"
+        invoking {
+            Innboks(
+
+                    systembruker = validSystembruker,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = invalidLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true)
+        } `should throw` FieldValidationException::class `with message containing` "link"
+    }
+
+    @Test
+    fun `should allow empty link`() {
+        val innboks = InnboksObjectMother.giveMeAktivInnboksWithLink("")
+        innboks.link `should be equal to` ""
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTransformerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.*
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.`with message containing`
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
 import org.amshove.kluent.`should contain`
 import org.amshove.kluent.`should throw`
 import org.amshove.kluent.invoking
@@ -129,7 +129,7 @@ class OppgaveTest {
 
     @Test
     fun `do not allow too long link`() {
-        val tooLongLink = "L".repeat(201)
+        val tooLongLink = "http://" + "L".repeat(201)
         invoking {
             Oppgave(
 
@@ -140,6 +140,26 @@ class OppgaveTest {
                     grupperingsId = validGrupperingsId,
                     tekst = validTekst,
                     link = tooLongLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    aktiv = true,
+                    eksternVarsling = false)
+        } `should throw` FieldValidationException::class `with message containing` "link"
+    }
+
+    @Test
+    fun `do not allow invalid link`() {
+        val invalidLink = "invalidUrl"
+        invoking {
+            Oppgave(
+
+                    systembruker = validSystembruker,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    eventId = validEventId,
+                    grupperingsId = validGrupperingsId,
+                    tekst = validTekst,
+                    link = invalidLink,
                     sistOppdatert = sistOppdatert,
                     sikkerhetsnivaa = validSikkerhetsnivaa,
                     aktiv = true,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTransformerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.*
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/AvroStatusoppdateringObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/AvroStatusoppdateringObjectMother.kt
@@ -7,7 +7,7 @@ object AvroStatusoppdateringObjectMother {
 
     private val defaultLopenummer = 1
     private val defaultFodselsnr = "12345"
-    private val defaultLink = "dummyLink"
+    private val defaultLink = "http://dummyLink"
     private val defaultSikkerhetsnivaa = 4
     private val defaultStatusGlobal = "SENDT"
     private val defaultStatusIntern = "dummyStatusIntern"

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringObjectMother.kt
@@ -7,17 +7,22 @@ object StatusoppdateringObjectMother {
 
     fun giveMeStatusoppdatering(eventId: String, fodselsnummer: String): Statusoppdatering {
         val systembruker = "dummySystembruker"
-        return giveMeStatusoppdatering(eventId, fodselsnummer, systembruker)
+        val link = "https://nav.no/systemX/$eventId"
+        return giveMeStatusoppdatering(eventId, fodselsnummer, systembruker, link)
     }
 
-    fun giveMeStatusoppdatering(eventId: String, fodselsnummer: String, systembruker: String): Statusoppdatering {
+    fun giveMeStatusoppdateringWithLink(link: String): Statusoppdatering {
+        return giveMeStatusoppdatering(eventId = "s-1", fodselsnummer = "1234", systembruker = "dummySystemUser", link = link)
+    }
+
+    fun giveMeStatusoppdatering(eventId: String, fodselsnummer: String, systembruker: String, link: String): Statusoppdatering {
         return Statusoppdatering(
                 systembruker = systembruker,
                 eventId = eventId,
                 eventTidspunkt = LocalDateTime.now(ZoneId.of("UTC")),
                 fodselsnummer = fodselsnummer,
                 grupperingsId = "systemA010",
-                link = "https://nav.no/systemX/$eventId",
+                link = link,
                 sikkerhetsnivaa = 4,
                 sistOppdatert = LocalDateTime.now(ZoneId.of("UTC")),
                 statusGlobal = "SENDT",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringObjectMother.kt
@@ -6,9 +6,7 @@ import java.time.ZoneId
 object StatusoppdateringObjectMother {
 
     fun giveMeStatusoppdatering(eventId: String, fodselsnummer: String): Statusoppdatering {
-        val systembruker = "dummySystembruker"
-        val link = "https://nav.no/systemX/$eventId"
-        return giveMeStatusoppdatering(eventId, fodselsnummer, systembruker, link)
+        return giveMeStatusoppdatering(eventId = eventId, fodselsnummer = fodselsnummer, systembruker = "dummySystembruker", link = "https://nav.no/systemX/$eventId")
     }
 
     fun giveMeStatusoppdateringWithLink(link: String): Statusoppdatering {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringTest.kt
@@ -1,7 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.statusoppdatering
 
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.common.`with message containing`
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain`
 import org.amshove.kluent.`should throw`
 import org.amshove.kluent.invoking
@@ -110,7 +111,7 @@ class StatusoppdateringTest {
 
     @Test
     fun `do not allow too long link`() {
-        val tooLongLink = "L".repeat(201)
+        val tooLongLink = "http://" + "L".repeat(201)
         invoking {
             Statusoppdatering(
                     systembruker = validSystembruker,
@@ -125,6 +126,31 @@ class StatusoppdateringTest {
                     statusIntern = validStatusIntern,
                     sakstema = validSakstema)
         } `should throw` FieldValidationException::class `with message containing` "link"
+    }
+
+    @Test
+    fun `do not allow invalid link`() {
+        val invalidLink = "invalidUrl"
+        invoking {
+            Statusoppdatering(
+                    systembruker = validSystembruker,
+                    eventId = validEventId,
+                    eventTidspunkt = eventTidspunkt,
+                    fodselsnummer = validFodselsnummer,
+                    grupperingsId = validGrupperingsId,
+                    link = invalidLink,
+                    sistOppdatert = sistOppdatert,
+                    sikkerhetsnivaa = validSikkerhetsnivaa,
+                    statusGlobal = validStatusGlobal,
+                    statusIntern = validStatusIntern,
+                    sakstema = validSakstema)
+        } `should throw` FieldValidationException::class `with message containing` "link"
+    }
+
+    @Test
+    fun `should allow empty link`() {
+        val statusoppdatering = StatusoppdateringObjectMother.giveMeStatusoppdateringWithLink("")
+        statusoppdatering.link `should be equal to` ""
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringTransformerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.statusoppdatering
 
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.exceptions.FieldValidationException
+import no.nav.brukernotifikasjon.schemas.builders.exception.FieldValidationException
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.createNokkel
 import org.amshove.kluent.*
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
All validering av event-typene fra Kafka skjer gjennom repo brukernotifikasjon-schemas. Dette betyr at vi kun trenger å endre i brukernotifikasjon-schemas hvis valideringskrav endrer seg.

Dette hører sammen med [PR-en](https://github.com/navikt/brukernotifikasjon-schemas/pull/19) som ligger i brukernotifikasjon-schemas. 
