### PR TITLE
Restrukturerte config for å få mer kontroll over når variabler knyttet til sikkerhet bør hentes.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2021.05.31-11.01-a95c65019ef8"
+val dittNavDependenciesVersion = "2021.06.03-11.34-36e206f4f27f"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/EndToEndTestIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/EndToEndTestIT.kt
@@ -82,7 +82,7 @@ class EndToEndTestIT {
         val beskjedRepository = BeskjedRepository(database)
         val beskjedPersistingService = BrukernotifikasjonPersistingService(beskjedRepository)
         val eventProcessor = BeskjedEventService(beskjedPersistingService, metricsProbe)
-        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED, enableSecurity = false)
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED)
         val kafkaConsumer = KafkaConsumer<NokkelIntern, BeskjedIntern>(consumerProps)
         val consumer = Consumer(topicen, kafkaConsumer, eventProcessor)
 

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/config/KafkaEmbed.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/config/KafkaEmbed.kt
@@ -9,8 +9,8 @@ import java.util.*
 
 object KafkaEmbed {
 
-    fun consumerProps(env: Environment, eventTypeToConsume: EventType, enableSecurity: Boolean = ConfigUtil.isCurrentlyRunningOnNais()): Properties {
-        return Kafka.consumerProps(env, eventTypeToConsume, enableSecurity).apply {
+    fun consumerProps(env: Environment, eventTypeToConsume: EventType): Properties {
+        return Kafka.consumerProps(env, eventTypeToConsume).apply {
             put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
         }
     }

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/MultipleTopicsConsumerTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/MultipleTopicsConsumerTest.kt
@@ -108,17 +108,17 @@ class MultipleTopicsConsumerTest {
     }
 
     private fun createInfoConsumer(env: Environment, BeskjedEventProcessor: SimpleEventCounterService<BeskjedIntern>): Consumer<BeskjedIntern> {
-        val kafkaProps = KafkaEmbed.consumerProps(env, EventType.BESKJED, enableSecurity = false)
+        val kafkaProps = KafkaEmbed.consumerProps(env, EventType.BESKJED)
         return setupConsumerForTheBeskjedTopic(kafkaProps, BeskjedEventProcessor)
     }
 
     private fun createOppgaveConsumer(env: Environment, oppgaveEventProcessor: SimpleEventCounterService<OppgaveIntern>): Consumer<OppgaveIntern> {
-        val kafkaProps = KafkaEmbed.consumerProps(env, EventType.OPPGAVE, enableSecurity = false)
+        val kafkaProps = KafkaEmbed.consumerProps(env, EventType.OPPGAVE)
         return setupConsumerForTheOppgaveTopic(kafkaProps, oppgaveEventProcessor)
     }
 
     private fun createInnboksConsumer(env: Environment, innboksEventProcessor: SimpleEventCounterService<InnboksIntern>): Consumer<InnboksIntern> {
-        val kafkaProps = KafkaEmbed.consumerProps(env, EventType.INNBOKS, enableSecurity = false)
+        val kafkaProps = KafkaEmbed.consumerProps(env, EventType.INNBOKS)
         return setupConsumerForTheInnboksTopic(kafkaProps, innboksEventProcessor)
     }
 

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/SingleTopicConsumerTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/SingleTopicConsumerTest.kt
@@ -46,7 +46,7 @@ class SingleTopicConsumerTest {
     fun `Lese inn alle testeventene fra Kafka`() {
         `Produserer noen testeventer`()
         val eventProcessor = SimpleEventCounterService<BeskjedIntern>()
-        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED, enableSecurity = false)
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED)
         val kafkaConsumer = KafkaConsumer<NokkelIntern, BeskjedIntern>(consumerProps)
         val consumer = Consumer(topicen, kafkaConsumer, eventProcessor)
 

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaTestUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/util/KafkaTestUtil.kt
@@ -4,6 +4,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.common.JAASCredential
 import no.nav.common.KafkaEnvironment
 import no.nav.personbruker.dittnav.eventaggregator.config.Environment
+import no.nav.personbruker.dittnav.eventaggregator.config.SecurityConfig
 import org.apache.avro.generic.GenericRecord
 
 object KafkaTestUtil {
@@ -51,12 +52,8 @@ object KafkaTestUtil {
                 influxdbPassword = "",
                 influxdbRetentionPolicy = "",
                 aivenBrokers = embeddedEnv.brokersURL.substringAfterLast("/"),
-                aivenTruststorePath = "kafkaTruststorePathIkkeIBrukHer",
-                aivenKeystorePath = "kafkaKeystorePathIkkeIBrukerHer",
-                aivenCredstorePassword = "kafkaCredstorePasswordIkkeIBrukHer",
                 aivenSchemaRegistry = embeddedEnv.schemaRegistry!!.url,
-                aivenSchemaRegistryUser = username,
-                aivenSchemaRegistryPassword = password
+                securityConfig = SecurityConfig(enabled = false)
         )
     }
 

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTestIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTestIT.kt
@@ -32,7 +32,7 @@ class ConsumerTestIT {
 
         val embeddedEnv = KafkaTestUtil.createKafkaEmbeddedInstanceWithNumPartitions(listOf(topic), 4)
         val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
-        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED, enableSecurity = false).apply {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED).apply {
             put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
         }
 
@@ -60,7 +60,7 @@ class ConsumerTestIT {
 
         val embeddedEnv = KafkaTestUtil.createKafkaEmbeddedInstanceWithNumPartitions(listOf(topic), 4)
         val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
-        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED, enableSecurity = false).apply {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED).apply {
             put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
         }
 
@@ -88,7 +88,7 @@ class ConsumerTestIT {
 
         val embeddedEnv = KafkaTestUtil.createKafkaEmbeddedInstanceWithNumPartitions(listOf(topic), 4)
         val testEnvironment = KafkaTestUtil.createEnvironmentForEmbeddedKafka(embeddedEnv)
-        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED, enableSecurity = false).apply {
+        val consumerProps = KafkaEmbed.consumerProps(testEnvironment, EventType.BESKJED).apply {
             put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
         }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Environment.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.config
 import no.nav.personbruker.dittnav.common.util.config.IntEnvVar.getEnvVarAsInt
 import no.nav.personbruker.dittnav.common.util.config.StringEnvVar
 import no.nav.personbruker.dittnav.common.util.config.StringEnvVar.getEnvVar
+import no.nav.personbruker.dittnav.eventaggregator.config.ConfigUtil.isCurrentlyRunningOnNais
 
 data class Environment(val username: String = getEnvVar("SERVICEUSER_USERNAME"),
                        val password: String = getEnvVar("SERVICEUSER_PASSWORD"),
@@ -16,19 +17,33 @@ data class Environment(val username: String = getEnvVar("SERVICEUSER_USERNAME"),
                        val influxdbPassword: String = getEnvVar("INFLUXDB_PASSWORD"),
                        val influxdbRetentionPolicy: String = getEnvVar("INFLUXDB_RETENTION_POLICY"),
                        val aivenBrokers: String = getEnvVar("KAFKA_BROKERS"),
-                       val aivenTruststorePath: String = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
-                       val aivenKeystorePath: String = getEnvVar("KAFKA_KEYSTORE_PATH"),
-                       val aivenCredstorePassword: String = getEnvVar("KAFKA_CREDSTORE_PASSWORD"),
                        val aivenSchemaRegistry: String = getEnvVar("KAFKA_SCHEMA_REGISTRY"),
-                       val aivenSchemaRegistryUser: String = getEnvVar("KAFKA_SCHEMA_REGISTRY_USER"),
-                       val aivenSchemaRegistryPassword: String = getEnvVar("KAFKA_SCHEMA_REGISTRY_PASSWORD"),
+                       val securityConfig: SecurityConfig = SecurityConfig(isCurrentlyRunningOnNais()),
                        val dbUser: String = getEnvVar("DB_USERNAME"),
                        val dbPassword: String = getEnvVar("DB_PASSWORD"),
                        val dbHost: String = getEnvVar("DB_HOST"),
                        val dbPort: String = getEnvVar("DB_PORT"),
                        val dbName: String = getEnvVar("DB_DATABASE"),
-                       val dbUrl: String = "jdbc:postgresql://${dbHost}:${dbPort}/${dbName}"
+                       val dbUrl: String = getDbUrl(dbHost, dbPort, dbName)
 
+)
+
+data class SecurityConfig(
+        val enabled: Boolean,
+
+        val variables: SecurityVars? = if (enabled) {
+            SecurityVars()
+        } else {
+            null
+        }
+)
+
+data class SecurityVars(
+        val aivenTruststorePath: String = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
+        val aivenKeystorePath: String = getEnvVar("KAFKA_KEYSTORE_PATH"),
+        val aivenCredstorePassword: String = getEnvVar("KAFKA_CREDSTORE_PASSWORD"),
+        val aivenSchemaRegistryUser: String = getEnvVar("KAFKA_SCHEMA_REGISTRY_USER"),
+        val aivenSchemaRegistryPassword: String = getEnvVar("KAFKA_SCHEMA_REGISTRY_PASSWORD")
 )
 
 fun isOtherEnvironmentThanProd() = System.getenv("NAIS_CLUSTER_NAME") != "prod-sbs"
@@ -44,3 +59,11 @@ fun shouldPollInnboks() = StringEnvVar.getOptionalEnvVar("POLL_INNBOKS", "false"
 fun shouldPollStatusoppdatering() = StringEnvVar.getOptionalEnvVar("POLL_STATUSOPPDATERING", "false").toBoolean()
 
 fun shouldPollDone() = StringEnvVar.getOptionalEnvVar("POLL_DONE", "false").toBoolean()
+
+fun getDbUrl(host: String, port: String, name: String): String {
+    return if (host.endsWith(":$port")) {
+        "jdbc:postgresql://${host}/$name"
+    } else {
+        "jdbc:postgresql://${host}:${port}/${name}"
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/KafkaConsumerSetup.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/KafkaConsumerSetup.kt
@@ -109,16 +109,4 @@ object KafkaConsumerSetup {
         val kafkaConsumer = KafkaConsumer<NokkelIntern, StatusoppdateringIntern>(kafkaProps)
         return Consumer(Kafka.statusoppdateringHovedTopicName, kafkaConsumer, eventProcessor)
     }
-
-    fun <T> createCountConsumer(eventType: EventType,
-                                topic: String,
-                                environment: Environment,
-                                enableSecurity: Boolean = ConfigUtil.isCurrentlyRunningOnNais()): KafkaConsumer<NokkelIntern, T> {
-
-        val kafkaProps = Kafka.counterConsumerProps(environment, eventType, enableSecurity)
-        val consumer = KafkaConsumer<NokkelIntern, T>(kafkaProps)
-        consumer.subscribe(listOf(topic))
-        return consumer
-    }
-
 }


### PR DESCRIPTION
Sentraliserer `isCurrentlyRunningOnNais`-sjekken, og henter kun variabler knyttet til sikkerhet ved behov.

La til nye variabler i dittnav-dependencies, og gjorde en liten tilpasning rundt db-host og portnummer, slik at det igjen skal være mulig å kjøre aggregator lokalt.