### PR TITLE
Dobler db-resurser i prod.

### DIFF
--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -38,7 +38,7 @@ spec:
     sqlInstances:
       - name: brukernotifikasjon-cache
         type: POSTGRES_11
-        tier: db-custom-2-12288
+        tier: db-custom-4-24576
         diskType: SSD
         highAvailability: true
         diskSize: 100


### PR DESCRIPTION
Gir oss flere resurser for brukernotifikasjon-cache (4 cpu 24GB) for å tilnærme det vi har on-prem i dag (8 cpu og 32GB).