### PR TITLE
Øker antall done eventer som hentes fra ventetabellen, og sorterer dem etter nyeste først.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepository.kt
@@ -64,7 +64,7 @@ class DoneRepository(private val database: Database) : BrukernotifikasjonReposit
     suspend fun fetchAllDoneEventsWithLimit(): List<Done> {
         var resultat = emptyList<Done>()
         database.queryWithExceptionTranslation {
-            resultat = getAllDoneEventWithLimit(10000)
+            resultat = getAllDoneEventWithLimit(15000)
         }
         return resultat
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/doneQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/doneQueries.kt
@@ -8,7 +8,7 @@ import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Types
 
-private const val allDoneQuery = "SELECT * FROM done"
+private const val allDoneQuery = "SELECT * FROM done ORDER BY eventtidspunkt DESC"
 
 fun Connection.getAllDoneEvent(): List<Done> =
         prepareStatement(allDoneQuery)


### PR DESCRIPTION
Hensikten med dette er å løse et tilfelle vi har der gamle done-eventer i ventetabellen Disse finner aldri match, og sperrer for nye done-eventer som da aldri blir behandlet.

I gcp er dette løst ved å rotere på hvilke eventer som blir behandlet.