### PR TITLE
Felt for forstBehandlet

### DIFF
--- a/src/main/resources/db/migration/V1.1.15__Legger_til_felt_behandlet.sql
+++ b/src/main/resources/db/migration/V1.1.15__Legger_til_felt_behandlet.sql
@@ -3,9 +3,3 @@ ALTER TABLE oppgave ADD COLUMN forstBehandlet timestamp without time zone;
 ALTER TABLE innboks ADD COLUMN forstBehandlet timestamp without time zone;
 ALTER TABLE statusoppdatering ADD COLUMN forstBehandlet timestamp without time zone;
 ALTER TABLE done ADD COLUMN forstBehandlet timestamp without time zone;
-
-update beskjed set forstBehandlet = case when eventtidspunkt < '1975-01-01' then to_timestamp(extract(epoch from eventtidspunkt) * 1000) at time zone 'UTC' else eventtidspunkt end;
-update oppgave set forstBehandlet = case when eventtidspunkt < '1975-01-01' then to_timestamp(extract(epoch from eventtidspunkt) * 1000) at time zone 'UTC' else eventtidspunkt end;
-update innboks set forstBehandlet = case when eventtidspunkt < '1975-01-01' then to_timestamp(extract(epoch from eventtidspunkt) * 1000) at time zone 'UTC' else eventtidspunkt end;
-update statusoppdatering set forstBehandlet = case when eventtidspunkt < '1975-01-01' then to_timestamp(extract(epoch from eventtidspunkt) * 1000) at time zone 'UTC' else eventtidspunkt end;
-update done set forstBehandlet = case when eventtidspunkt < '1975-01-01' then to_timestamp(extract(epoch from eventtidspunkt) * 1000) at time zone 'UTC' else eventtidspunkt end;

--- a/src/main/resources/db/migration/V1.1.16__Legger_paa_indekser_eventtidspunkt.sql
+++ b/src/main/resources/db/migration/V1.1.16__Legger_paa_indekser_eventtidspunkt.sql
@@ -1,0 +1,14 @@
+CREATE INDEX IF NOT EXISTS beskjed_index_eventtidspunkt
+    ON beskjed (eventtidspunkt);
+
+CREATE INDEX IF NOT EXISTS innboks_index_eventtidspunkt
+    ON innboks (eventtidspunkt);
+
+CREATE INDEX IF NOT EXISTS oppgave_index_eventtidspunkt
+    ON oppgave (eventtidspunkt);
+
+CREATE INDEX IF NOT EXISTS statusoppdatering_index_eventtidspunkt
+    ON statusoppdatering (eventtidspunkt);
+
+CREATE INDEX IF NOT EXISTS done_index_eventtidspunkt
+    ON done (eventtidspunkt);


### PR DESCRIPTION
Fortsettelse av https://github.com/navikt/dittnav-event-aggregator/pull/179

Denne feilet ved deploy pga Flyway-kjøring som tok svært lang tid. Fjerner disse spørringene, som var egentlig er unødvendige. Dette håndteres i kode ved ny innlesing til cachen. Har kjørt dette manuelt utenom Flyway for cachen nå. 

Indeksene som blir lagt på er egentlig unødvendige, men det gjør jo ingen skade om de er der. De har allerede blitt kjørt av Flyway.