### PR TITLE
Index fix

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/beskjedQueries.kt
@@ -10,6 +10,9 @@ import java.sql.ResultSet
 import java.sql.Types
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
+
+private val EPOCH_START = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC)
 
 private val createQuery = """INSERT INTO beskjed (systembruker, eventTidspunkt, forstBehandlet, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, synligFremTil, aktiv, eksternVarsling, prefererteKanaler, namespace, appnavn)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
@@ -59,9 +62,10 @@ fun Connection.setBeskjederAktivflagg(doneEvents: List<Done>, aktiv: Boolean) {
 
 fun Connection.getExpiredBeskjedFromCursor(): List<Beskjed> {
     val now = LocalDateTime.now(ZoneId.of("UTC"))
-    return prepareStatement("""SELECT * FROM beskjed WHERE aktiv = true AND synligFremTil <= ? LIMIT 10000""")
+    return prepareStatement("""SELECT * FROM beskjed WHERE aktiv = true AND synligFremTil between ? and ? LIMIT 10000""")
             .use {
-                it.setObject(1, now, Types.TIMESTAMP)
+                it.setObject(1, EPOCH_START, Types.TIMESTAMP)
+                it.setObject(2, now, Types.TIMESTAMP)
                 it.executeQuery().list { toBeskjed() }
             }
 }

--- a/src/main/resources/db/migration/V1.1.17__Fjern_index_eventTidspunkt.sql
+++ b/src/main/resources/db/migration/V1.1.17__Fjern_index_eventTidspunkt.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS beskjed_index_eventtidspunkt;
+DROP INDEX IF EXISTS innboks_index_eventtidspunkt;
+DROP INDEX IF EXISTS oppgave_index_eventtidspunkt;
+DROP INDEX IF EXISTS statusoppdatering_index_eventtidspunkt;
+DROP INDEX IF EXISTS done_index_eventtidspunkt;

--- a/src/main/resources/db/migration/V1.1.18__Legger_paa_indekser_synligFremTil.sql
+++ b/src/main/resources/db/migration/V1.1.18__Legger_paa_indekser_synligFremTil.sql
@@ -1,0 +1,5 @@
+CREATE INDEX IF NOT EXISTS beskjed_index_synligfremtil
+    ON beskjed (synligFremTil);
+
+CREATE INDEX IF NOT EXISTS oppgave_index_synligfremtil
+    ON oppgave (synligFremTil);

--- a/src/main/resources/db/migration/V1.1.19__Legger_til_constraint_eventId.sql
+++ b/src/main/resources/db/migration/V1.1.19__Legger_til_constraint_eventId.sql
@@ -1,0 +1,5 @@
+ALTER TABLE beskjed ADD CONSTRAINT beskjed_unique_eventid UNIQUE (eventid);
+ALTER TABLE oppgave ADD CONSTRAINT oppgave_unique_eventid UNIQUE (eventid);
+ALTER TABLE innboks ADD CONSTRAINT innboks_unique_eventid UNIQUE (eventid);
+ALTER TABLE statusoppdatering ADD CONSTRAINT statusoppdatering_unique_eventid UNIQUE (eventid);
+ALTER TABLE done ADD CONSTRAINT done_unique_eventid UNIQUE (eventid);

--- a/src/main/resources/db/migration/V1.1.20__Fjern_constraint_eventId_produsent.sql
+++ b/src/main/resources/db/migration/V1.1.20__Fjern_constraint_eventId_produsent.sql
@@ -1,0 +1,5 @@
+ALTER TABLE beskjed DROP CONSTRAINT beskjedeventidprodusent;
+ALTER TABLE oppgave DROP CONSTRAINT oppgaveeventidprodusent;
+ALTER TABLE innboks DROP CONSTRAINT innbokseventidprodusent;
+ALTER TABLE statusoppdatering DROP CONSTRAINT statusoppdateringseventerunikmedidogprodusent;
+ALTER TABLE done DROP CONSTRAINT doneeventidprodusent;

--- a/src/main/resources/db/migration/V1.1.21__Legger_til_index_fnr.sql
+++ b/src/main/resources/db/migration/V1.1.21__Legger_til_index_fnr.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS beskjed_fnr ON beskjed(fodselsnummer);
+CREATE INDEX IF NOT EXISTS oppgave_fnr ON oppgave(fodselsnummer);
+CREATE INDEX IF NOT EXISTS innboks_fnr ON innboks(fodselsnummer);
+CREATE INDEX IF NOT EXISTS statusoppdatering_fnr ON statusoppdatering(fodselsnummer);

--- a/src/main/resources/db/migration/V1.1.22__Fjerner_index_fnr_aktiv.sql
+++ b/src/main/resources/db/migration/V1.1.22__Fjerner_index_fnr_aktiv.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS beskjed_index_fnr_aktiv;
+DROP INDEX IF EXISTS oppgave_index_fnr_aktiv;
+DROP INDEX IF EXISTS innboks_index_fnr_aktiv;

--- a/src/main/resources/db/migration/V1.1.23__Fjerner_index_used_in_view.sql
+++ b/src/main/resources/db/migration/V1.1.23__Fjerner_index_used_in_view.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS beskjed_index_for_fields_used_in_view;
+DROP INDEX IF EXISTS oppgave_index_for_fields_used_in_view;
+DROP INDEX IF EXISTS innboks_index_for_fields_used_in_view;


### PR DESCRIPTION
Fjerner indekser som ble brukt på uventet måte av postgres sin query-planner:

- Indeks `<eventType>_index_for_fields_used_in_view` ble kun brukt til å gjøre et oppslag på eventId alene. Constraint `<eventType>eventidprodusent`  er ikke lenger relevant ettersom uniqueness defineres på tvers av produsenter.  Begge disse har blitt erstattet med en constraint på eventId alene. 

- Indeks `<eventType>_index__fnr_aktiv` ble erstattet med indeks på fodselsNummer alene, av samme årsak som over.

- Indeks på eventTidspunkt er fjernet. Dette var kun brukt til å hjelpe en migrering.

- Lagt til indeks på synligFremTil. Endret litt på spørring etter utgåtte eventer slik at denne indeksen blir brukt. 


Mange spørringer ser marginal forbedring i ytelse. Enkelte spørringer ser enorm forbedring. For eksempel går spørring etter utgåtte eventer for oppgave fra ~24 sekunder til ~100ms.  

Lagringsplass brukt totalt og til indekser går fra henholdsvis ~27GB og ~14GB til ~17GB og ~3GB. 