### PR TITLE
Doknot status

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
 }
 
 dependencies {
+    implementation("com.github.navikt:doknotifikasjon-schemas:1.2022.06.07-10.21-210529ac5c88")
     implementation("com.github.navikt:brukernotifikasjon-schemas:1.2022.04.26-11.25-7155b5142c85")
     implementation("com.github.navikt:brukernotifikasjon-schemas-internal:1.2022.04.27-11.14-a4039fef5785")
     implementation(DittNAV.Common.utils)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedEventService.kt
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory
 class BeskjedEventService(
         private val persistingService: BrukernotifikasjonPersistingService<Beskjed>,
         private val metricsProbe: EventMetricsProbe
-) : EventBatchProcessorService<BeskjedIntern> {
+) : EventBatchProcessorService<NokkelIntern, BeskjedIntern> {
 
     private val log: Logger = LoggerFactory.getLogger(BeskjedEventService::class.java)
 
@@ -48,12 +48,12 @@ class BeskjedEventService(
     }
 
     private fun EventMetricsSession.countDuplicateKeyEvents(result: ListPersistActionResult<Beskjed>) {
-        if (result.foundConflictingKeys()) {
+        if (result.foundUnalteredEntitites()) {
 
-            val constraintErrors = result.getConflictingEntities().size
+            val constraintErrors = result.getUnalteredEntities().size
             val totalEntities = result.getAllEntities().size
 
-            result.getConflictingEntities()
+            result.getUnalteredEntities()
                     .groupingBy { beskjed -> Produsent(beskjed.appnavn, beskjed.namespace) }
                     .eachCount()
                     .forEach { (produsent, duplicates) ->

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedRepository.kt
@@ -25,4 +25,9 @@ class BeskjedRepository(private val database: Database) : BrukernotifikasjonRepo
         }
     }
 
+    suspend fun getBeskjedWithEksternVarslingForEventIds(eventIds: List<String>): List<Beskjed> {
+        return database.queryWithExceptionTranslation {
+            getBeskjedWithEksternVarslingForEventIds(eventIds)
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/EventBatchProcessorService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/EventBatchProcessorService.kt
@@ -4,16 +4,16 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 
-interface EventBatchProcessorService<N, T> {
+interface EventBatchProcessorService<K, V> {
 
-    suspend fun processEvents(events: ConsumerRecords<N, T>)
+    suspend fun processEvents(events: ConsumerRecords<K, V>)
 
-    val ConsumerRecord<NokkelIntern, T>.namespace: String get() = key().getNamespace()
+    val ConsumerRecord<NokkelIntern, V>.namespace: String get() = key().getNamespace()
 
-    val ConsumerRecord<NokkelIntern, T>.appnavn: String get() = key().getAppnavn()
+    val ConsumerRecord<NokkelIntern, V>.appnavn: String get() = key().getAppnavn()
 
-    val ConsumerRecord<NokkelIntern, T>.systembruker: String get() = key().getSystembruker()
+    val ConsumerRecord<NokkelIntern, V>.systembruker: String get() = key().getSystembruker()
 
-    val ConsumerRecord<NokkelIntern, T>.eventId: String get() = key().getEventId()
+    val ConsumerRecord<NokkelIntern, V>.eventId: String get() = key().getEventId()
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/EventBatchProcessorService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/EventBatchProcessorService.kt
@@ -4,9 +4,9 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 
-interface EventBatchProcessorService<T> {
+interface EventBatchProcessorService<N, T> {
 
-    suspend fun processEvents(events: ConsumerRecords<NokkelIntern, T>)
+    suspend fun processEvents(events: ConsumerRecords<N, T>)
 
     val ConsumerRecord<NokkelIntern, T>.namespace: String get() = key().getNamespace()
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/PersistActionResult.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/PersistActionResult.kt
@@ -1,32 +1,18 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.database
 
 class PersistActionResult private constructor(
-        val entityId: Int, val wasSuccessful: Boolean, val persistOutcome: PersistFailureReason) {
-
-    inline fun onSuccess(action: (Int) -> Unit): PersistActionResult {
-        if (wasSuccessful) {
-            action(entityId)
-        }
-        return this
-    }
-
-    inline fun onFailure(action: (PersistFailureReason) -> Unit): PersistActionResult {
-        if (!wasSuccessful) {
-            action(persistOutcome)
-        }
-        return this
-    }
+        val entityId: Int, val persistOutcome: PersistOutcome) {
 
     companion object {
         fun success(entityId: Int): PersistActionResult =
-                PersistActionResult(entityId, true, PersistFailureReason.NO_ERROR)
+                PersistActionResult(entityId, PersistOutcome.SUCCESS)
 
-        fun failure(reason: PersistFailureReason): PersistActionResult =
-                PersistActionResult(-1, false, reason)
+        fun failure(reason: PersistOutcome): PersistActionResult =
+                PersistActionResult(-1, reason)
     }
 }
 
 
-enum class PersistFailureReason {
-    NO_ERROR, CONFLICTING_KEYS, UNKNOWN
+enum class PersistOutcome {
+    SUCCESS, NO_INSERT_OR_UPDATE
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonQueries.kt
@@ -1,8 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.database.entity
 
 import no.nav.personbruker.dittnav.eventaggregator.common.database.util.list
+import no.nav.personbruker.dittnav.eventaggregator.common.database.util.toVarcharArray
 import no.nav.personbruker.dittnav.eventaggregator.config.EventType
-import java.sql.Array
 import java.sql.Connection
 import java.sql.ResultSet
 
@@ -25,6 +25,3 @@ private fun ResultSet.toBrukernotifikasjon(): Brukernotifikasjon {
 }
 
 
-private fun Connection.toVarcharArray(stringList: List<String>): Array {
-    return createArrayOf("VARCHAR", stringList.toTypedArray())
-}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/Consumer.kt
@@ -18,10 +18,10 @@ import java.time.Duration
 import java.time.temporal.ChronoUnit
 import kotlin.coroutines.CoroutineContext
 
-class Consumer<T>(
+class Consumer<K, V>(
     val topic: String,
-    private val kafkaConsumer: org.apache.kafka.clients.consumer.Consumer<NokkelIntern, T>,
-    val eventBatchProcessorService: EventBatchProcessorService<T>,
+    private val kafkaConsumer: org.apache.kafka.clients.consumer.Consumer<K, V>,
+    val eventBatchProcessorService: EventBatchProcessorService<K, V>,
     val job: Job = Job(),
     val maxPollTimeout: Long = 100L
 ) : CoroutineScope, HealthCheck {
@@ -107,7 +107,7 @@ class Consumer<T>(
         }
     }
 
-    fun ConsumerRecords<NokkelIntern, T>.containsEvents() = count() > 0
+    fun ConsumerRecords<K, V>.containsEvents() = count() > 0
 
     private suspend fun rollbackOffset() {
         withContext(Dispatchers.IO) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/kafkaConsumer.kt
@@ -1,8 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.kafka
 
-import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
-
-fun <T> org.apache.kafka.clients.consumer.Consumer<NokkelIntern, T>.rollbackToLastCommitted() {
+fun <K, V> org.apache.kafka.clients.consumer.Consumer<K, V>.rollbackToLastCommitted() {
     val assignedPartitions = assignment()
     val partitionCommittedInfo = committed(assignedPartitions)
     partitionCommittedInfo.forEach { (partition, lastCommitted) ->

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Environment.kt
@@ -30,7 +30,8 @@ data class Environment(val username: String = getEnvVar("SERVICEUSER_USERNAME"),
                        val innboksInternTopicName: String = getEnvVar("INTERN_INNBOKS_TOPIC"),
                        val statusoppdateringInternTopicName: String = getEnvVar("INTERN_STATUSOPPDATERING_TOPIC"),
                        val doneInternTopicName: String = getEnvVar("INTERN_DONE_TOPIC"),
-                       val doneInputTopicName: String = getEnvVar("INPUT_DONE_TOPIC")
+                       val doneInputTopicName: String = getEnvVar("INPUT_DONE_TOPIC"),
+                       val doknotifikasjonStatusTopicName: String = getEnvVar("DOKNOTIFIKASJON_STATUS_TOPIC")
 
 )
 
@@ -65,6 +66,8 @@ fun shouldPollInnboks() = StringEnvVar.getOptionalEnvVar("POLL_INNBOKS", "false"
 fun shouldPollStatusoppdatering() = StringEnvVar.getOptionalEnvVar("POLL_STATUSOPPDATERING", "false").toBoolean()
 
 fun shouldPollDone() = StringEnvVar.getOptionalEnvVar("POLL_DONE", "false").toBoolean()
+
+fun shouldPollDoknotifikasjonStatus() = StringEnvVar.getOptionalEnvVar("POLL_DOKNOTIFIKASJON_STATUS", "false").toBoolean()
 
 fun getDbUrl(host: String, port: String, name: String): String {
     return if (host.endsWith(":$port")) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Kafka.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/Kafka.kt
@@ -46,8 +46,12 @@ object Kafka {
         }
     }
 
-    fun consumerProps(env: Environment, eventtypeToConsume: EventType): Properties {
-        val groupIdAndEventType = buildGroupIdIncludingEventType(env, eventtypeToConsume)
+    fun consumerPropsForEventType(env: Environment, eventtypeToConsume: EventType): Properties {
+        return consumerProps(env, eventtypeToConsume.eventType)
+    }
+
+    fun consumerProps(env: Environment, groupIdSuffix: String): Properties {
+        val groupIdAndEventType = buildGroupIdIncludingEventType(env, groupIdSuffix)
         return Properties().apply {
             put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, env.aivenBrokers)
             put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, env.aivenSchemaRegistry)
@@ -82,7 +86,7 @@ object Kafka {
         }
     }
 
-    private fun buildGroupIdIncludingEventType(env: Environment, eventTypeToConsume: EventType) =
-            env.groupId + eventTypeToConsume.eventType
+    private fun buildGroupIdIncludingEventType(env: Environment, eventTypeToConsume: String) =
+            env.groupId + eventTypeToConsume
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/KafkaConsumerSetup.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/config/KafkaConsumerSetup.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.config
 
 import no.nav.brukernotifikasjon.schemas.internal.*
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
 import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.Consumer
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -29,6 +30,12 @@ object KafkaConsumerSetup {
             appContext.doneConsumer.startPolling()
         } else {
             log.info("Unnlater å starte polling av done")
+        }
+
+        if (shouldPollDoknotifikasjonStatus()) {
+            appContext.doknotifikasjonStatusConsumer.startPolling()
+        } else {
+            log.info("Unnlater å starte polling av doknotifikasjon status")
         }
 
         if (isOtherEnvironmentThanProd()) {
@@ -67,6 +74,10 @@ object KafkaConsumerSetup {
             appContext.doneConsumer.stopPolling()
         }
 
+        if (!appContext.doknotifikasjonStatusConsumer.isCompleted()) {
+            appContext.doknotifikasjonStatusConsumer.stopPolling()
+        }
+
         if (isOtherEnvironmentThanProd()) {
             if (!appContext.innboksConsumer.isCompleted()) {
                 appContext.innboksConsumer.stopPolling()
@@ -85,28 +96,33 @@ object KafkaConsumerSetup {
         startAllKafkaPollers(appContext)
     }
 
-    fun setupConsumerForTheBeskjedTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<BeskjedIntern>, topic: String): Consumer<BeskjedIntern> {
+    fun setupConsumerForTheBeskjedTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<NokkelIntern, BeskjedIntern>, topic: String): Consumer<NokkelIntern, BeskjedIntern> {
         val kafkaConsumer = KafkaConsumer<NokkelIntern, BeskjedIntern>(kafkaProps)
         return Consumer(topic, kafkaConsumer, eventProcessor)
     }
 
-    fun setupConsumerForTheOppgaveTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<OppgaveIntern>, topic: String): Consumer<OppgaveIntern> {
+    fun setupConsumerForTheOppgaveTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<NokkelIntern, OppgaveIntern>, topic: String): Consumer<NokkelIntern, OppgaveIntern> {
         val kafkaConsumer = KafkaConsumer<NokkelIntern, OppgaveIntern>(kafkaProps)
         return Consumer(topic, kafkaConsumer, eventProcessor)
     }
 
-    fun setupConsumerForTheInnboksTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<InnboksIntern>, topic: String): Consumer<InnboksIntern> {
+    fun setupConsumerForTheInnboksTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<NokkelIntern, InnboksIntern>, topic: String): Consumer<NokkelIntern, InnboksIntern> {
         val kafkaConsumer = KafkaConsumer<NokkelIntern, InnboksIntern>(kafkaProps)
         return Consumer(topic, kafkaConsumer, eventProcessor)
     }
 
-    fun setupConsumerForTheDoneTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<DoneIntern>, topic: String): Consumer<DoneIntern> {
+    fun setupConsumerForTheDoneTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<NokkelIntern, DoneIntern>, topic: String): Consumer<NokkelIntern, DoneIntern> {
         val kafkaConsumer = KafkaConsumer<NokkelIntern, DoneIntern>(kafkaProps)
         return Consumer(topic, kafkaConsumer, eventProcessor)
     }
 
-    fun setupConsumerForTheStatusoppdateringTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<StatusoppdateringIntern>, topic: String): Consumer<StatusoppdateringIntern> {
+    fun setupConsumerForTheStatusoppdateringTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<NokkelIntern, StatusoppdateringIntern>, topic: String): Consumer<NokkelIntern, StatusoppdateringIntern> {
         val kafkaConsumer = KafkaConsumer<NokkelIntern, StatusoppdateringIntern>(kafkaProps)
+        return Consumer(topic, kafkaConsumer, eventProcessor)
+    }
+
+    fun setupConsumerForTheDoknotifikasjonStatusTopic(kafkaProps: Properties, eventProcessor: EventBatchProcessorService<String, DoknotifikasjonStatus>, topic: String): Consumer<String, DoknotifikasjonStatus> {
+        val kafkaConsumer = KafkaConsumer<String, DoknotifikasjonStatus>(kafkaProps)
         return Consumer(topic, kafkaConsumer, eventProcessor)
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusRepository.kt
@@ -1,0 +1,19 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
+import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
+import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
+
+class DoknotifikasjonStatusRepository(private val database: Database) {
+    suspend fun updateStatusesForBeskjed(dokStatuses: List<DoknotifikasjonStatus>): ListPersistActionResult<DoknotifikasjonStatus> {
+        return database.queryWithExceptionTranslation {
+            upsertDoknotifikasjonStatusForBeskjed(dokStatuses)
+        }
+    }
+
+    suspend fun updateStatusesForOppgave(dokStatuses: List<DoknotifikasjonStatus>): ListPersistActionResult<DoknotifikasjonStatus>  {
+        return database.queryWithExceptionTranslation {
+            upsertDoknotifikasjonStatusForOppgave(dokStatuses)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusService.kt
@@ -1,0 +1,29 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
+import no.nav.personbruker.dittnav.eventaggregator.common.EventBatchProcessorService
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.metrics.DoknotifikasjonStatusMetricsProbe
+import org.apache.kafka.clients.consumer.ConsumerRecords
+
+class DoknotifikasjonStatusService(
+    private val doknotifikasjonStatusUpdater: DoknotifikasjonStatusUpdater,
+    private val metricsProbe: DoknotifikasjonStatusMetricsProbe
+): EventBatchProcessorService<String, DoknotifikasjonStatus> {
+
+    override suspend fun processEvents(events: ConsumerRecords<String, DoknotifikasjonStatus>) {
+        metricsProbe.runWithMetrics {
+
+            val allStatuses = events.map { it.value() }
+
+            countStatuses(allStatuses)
+
+            val updateResultForBeskjed = doknotifikasjonStatusUpdater.updateStatusForBeskjed(allStatuses)
+
+            val updateResultForOppgave = doknotifikasjonStatusUpdater.updateStatusForOppgave(allStatuses)
+
+            recordUpdateResult(EventType.BESKJED_INTERN, updateResultForBeskjed)
+            recordUpdateResult(EventType.OPPGAVE_INTERN, updateResultForOppgave)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusUpdater.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusUpdater.kt
@@ -1,0 +1,65 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.Beskjed
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedRepository
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.Oppgave
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveRepository
+
+class DoknotifikasjonStatusUpdater(
+    private val beskjedRepository: BeskjedRepository,
+    private val oppgaveRepository: OppgaveRepository,
+    private val doknotifikasjonRepository: DoknotifikasjonStatusRepository) {
+
+    suspend fun updateStatusForBeskjed(dokStatus: List<DoknotifikasjonStatus>): UpdateStatusResult {
+        val eventIdRef = dokStatus.map { it.getBestillingsId() }
+
+        val beskjedCandidates = beskjedRepository.getBeskjedWithEksternVarslingForEventIds(eventIdRef)
+
+        val matchingStatuses = matchBeskjedWithDokStatus(beskjedCandidates, dokStatus)
+
+        val persistResult = doknotifikasjonRepository.updateStatusesForBeskjed(matchingStatuses)
+
+        val unmatchedStatuses = dokStatus - matchingStatuses
+
+        return UpdateStatusResult(
+            updatedStatuses = persistResult.getPersistedEntitites(),
+            unchangedStatuses = persistResult.getUnalteredEntities(),
+            unmatchedStatuses = unmatchedStatuses
+        )
+    }
+
+    suspend fun updateStatusForOppgave(dokStatus: List<DoknotifikasjonStatus>): UpdateStatusResult {
+        val bestillingsIdsToMatch = dokStatus.map { it.getBestillingsId() }
+
+        val oppgaveCandidates = oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(bestillingsIdsToMatch)
+
+        val matchingStatuses = matchOppgaveWithDokStatus(oppgaveCandidates, dokStatus)
+
+        val persistResult = doknotifikasjonRepository.updateStatusesForOppgave(matchingStatuses)
+
+        val unmatchedStatuses = dokStatus - matchingStatuses
+
+        return UpdateStatusResult(
+            updatedStatuses = persistResult.getPersistedEntitites(),
+            unchangedStatuses = persistResult.getUnalteredEntities(),
+            unmatchedStatuses = unmatchedStatuses
+        )
+    }
+
+    private fun matchBeskjedWithDokStatus(beskjedCandidates: List<Beskjed>,
+                                          dokStatus: List<DoknotifikasjonStatus>): List<DoknotifikasjonStatus> {
+
+        val appnavnEventIds = beskjedCandidates.map { it.appnavn to it.eventId }
+
+        return dokStatus.filter { appnavnEventIds.contains(it.getBestillerId() to it.getBestillingsId()) }
+    }
+
+    private fun matchOppgaveWithDokStatus(oppgaveCandidates: List<Oppgave>,
+                                          dokStatus: List<DoknotifikasjonStatus>): List<DoknotifikasjonStatus> {
+
+        val appnavnEventIds = oppgaveCandidates.map { it.appnavn to it.eventId }
+
+        return dokStatus.filter { appnavnEventIds.contains(it.getBestillerId() to it.getBestillingsId()) }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/UpdateStatusResult.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/UpdateStatusResult.kt
@@ -1,0 +1,9 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
+
+data class UpdateStatusResult(
+    val updatedStatuses: List<DoknotifikasjonStatus>,
+    val unchangedStatuses: List<DoknotifikasjonStatus>,
+    val unmatchedStatuses: List<DoknotifikasjonStatus>
+)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/doknotifikasjonStatusQuery.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/doknotifikasjonStatusQuery.kt
@@ -1,0 +1,62 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
+import no.nav.personbruker.dittnav.eventaggregator.common.database.util.executeBatchPersistQuery
+import no.nav.personbruker.dittnav.eventaggregator.common.database.util.toBatchPersistResult
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.Types
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+private const val upsertQueryBeskjed = """
+    INSERT INTO doknotifikasjon_status_beskjed(eventId, status, melding, distribusjonsId, tidspunkt, antall_oppdateringer) VALUES(?, ?, ?, ?, ?, 1)
+    ON CONFLICT (eventId) DO 
+        UPDATE SET 
+            status = excluded.status,
+            melding = excluded.melding,
+            distribusjonsId = excluded.distribusjonsId,
+            tidspunkt = excluded.tidspunkt,
+            antall_oppdateringer = doknotifikasjon_status_beskjed.antall_oppdateringer + 1
+        WHERE excluded.status != doknotifikasjon_status_beskjed.status 
+           OR excluded.melding != doknotifikasjon_status_beskjed.melding
+           OR excluded.distribusjonsId != doknotifikasjon_status_beskjed.distribusjonsId
+"""
+
+private const val upsertQueryOppgave = """
+    INSERT INTO doknotifikasjon_status_oppgave(eventId, status, melding, distribusjonsId, tidspunkt, antall_oppdateringer) VALUES(?, ?, ?, ?, ?, 1)
+    ON CONFLICT (eventId) DO 
+        UPDATE SET 
+            status = excluded.status,
+            melding = excluded.melding,
+            distribusjonsId = excluded.distribusjonsId,
+            tidspunkt = excluded.tidspunkt,
+            antall_oppdateringer = doknotifikasjon_status_oppgave.antall_oppdateringer + 1
+        WHERE excluded.status != doknotifikasjon_status_oppgave.status 
+           OR excluded.melding != doknotifikasjon_status_oppgave.melding
+           OR excluded.distribusjonsId != doknotifikasjon_status_oppgave.distribusjonsId
+"""
+
+fun Connection.upsertDoknotifikasjonStatusForBeskjed(statuses: List<DoknotifikasjonStatus>) =
+    executeBatchPersistQuery(upsertQueryBeskjed) {
+        statuses.forEach { dokStatus ->
+            buildStatementForSingleRow(dokStatus)
+            addBatch()
+        }
+    }.toBatchPersistResult(statuses)
+
+fun Connection.upsertDoknotifikasjonStatusForOppgave(statuses: List<DoknotifikasjonStatus>) =
+    executeBatchPersistQuery(upsertQueryOppgave) {
+        statuses.forEach { dokStatus ->
+            buildStatementForSingleRow(dokStatus)
+            addBatch()
+        }
+    }.toBatchPersistResult(statuses)
+
+private fun PreparedStatement.buildStatementForSingleRow(dokStatus: DoknotifikasjonStatus) {
+    setString(1, dokStatus.getBestillingsId())
+    setString(2, dokStatus.getStatus())
+    setString(3, dokStatus.getMelding())
+    setObject(4, dokStatus.getDistribusjonId(), Types.BIGINT)
+    setObject(5, LocalDateTime.now(ZoneId.of("UTC")), Types.TIMESTAMP)
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/metrics/DoknotifikasjonStatusMetricsProbe.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/metrics/DoknotifikasjonStatusMetricsProbe.kt
@@ -1,0 +1,73 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.metrics
+
+import no.nav.personbruker.dittnav.common.metrics.MetricsReporter
+import no.nav.personbruker.dittnav.eventaggregator.metrics.*
+
+class DoknotifikasjonStatusMetricsProbe(private val metricsReporter: MetricsReporter) {
+    suspend fun runWithMetrics(block: suspend DoknotifikasjonStatusMetricsSession.() -> Unit) {
+        val session = DoknotifikasjonStatusMetricsSession()
+        block.invoke(session)
+        val processingTime = session.timeElapsedSinceSessionStartNanos()
+
+        if (session.getTotalEventsProcessed() > 0) {
+            handleStatusesProcessed(session)
+            handleStatusesUpdated(session)
+            handleStatusesUnchanged(session)
+            handleStatusesUnmatched(session)
+            handleBatchInfo(session, processingTime)
+        }
+    }
+
+    private suspend fun handleStatusesProcessed(session: DoknotifikasjonStatusMetricsSession) {
+        session.getTotalEventsByProducer().forEach { (bestiller, count) ->
+
+            reportEvents(count, bestiller, KAFKA_DOKNOT_STATUS_TOTAL_PROCESSED)
+        }
+    }
+
+    private suspend fun handleStatusesUpdated(session: DoknotifikasjonStatusMetricsSession) {
+        reportForEachCount(KAFKA_DOKNOT_STATUS_UPDATED, session.getCountOfStatuesSuccessfullyUpdated())
+    }
+
+    private suspend fun handleStatusesUnchanged(session: DoknotifikasjonStatusMetricsSession) {
+        reportForEachCount(KAFKA_DOKNOT_STATUS_UNCHANGED, session.getCountOfStatuesWithNoChange())
+    }
+
+    private suspend fun handleStatusesUnmatched(session: DoknotifikasjonStatusMetricsSession) {
+        reportForEachCount(KAFKA_DOKNOT_STATUS_IGNORED, session.getCountOfStatuesWithNoMatch())
+    }
+
+    private suspend fun reportForEachCount(metricName: String, countList: List<TagPermutationWithCount>) {
+        countList.forEach { countByTags ->
+            reportEvents(
+                count = countByTags.count,
+                eventType = countByTags.eventType ,
+                status = countByTags.status,
+                producerName = countByTags.producer,
+                metricName = metricName
+            )
+        }
+    }
+
+    private suspend fun handleBatchInfo(session: DoknotifikasjonStatusMetricsSession, processingTime: Long) {
+        val fieldMap = listOf(
+            "totalEvents" to session.getTotalEventsProcessed(),
+            "processingTime" to processingTime
+        ).toMap()
+
+        metricsReporter.registerDataPoint(KAFKA_DOKNOT_STATUS_BATCH, fieldMap, emptyMap())
+    }
+
+    private suspend fun reportEvents(count: Int, producerName: String, metricName: String) {
+        metricsReporter.registerDataPoint(metricName, counterField(count), mapOf("producer" to producerName))
+    }
+
+    private suspend fun reportEvents(count: Int, eventType: String, status: String, producerName: String, metricName: String) {
+        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, status, producerName))
+    }
+
+    private fun counterField(events: Int): Map<String, Int> = listOf("counter" to events).toMap()
+
+    private fun createTagMap(eventType: String, status: String, producer: String): Map<String, String> =
+        listOf("eventType" to eventType, "status" to status, "producer" to producer).toMap()
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/metrics/DoknotifikasjonStatusMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/metrics/DoknotifikasjonStatusMetricsSession.kt
@@ -1,0 +1,69 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.metrics
+
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.UpdateStatusResult
+
+class DoknotifikasjonStatusMetricsSession {
+
+    private var allStatusesByProducer = emptyMap<String, Int>()
+    private val statusesSuccessfullyUpdatedByType = HashMap<EventType, List<DoknotifikasjonStatus>>()
+    private val statusesWithNoChange = HashMap<EventType, List<DoknotifikasjonStatus>>()
+    private val statusesWithoutMatch = HashMap<EventType, List<DoknotifikasjonStatus>>()
+
+    private val startTime = System.nanoTime()
+
+    fun countStatuses(dokStatus: List<DoknotifikasjonStatus>) {
+        allStatusesByProducer = countStatusesPerProducer(dokStatus)
+    }
+
+    fun recordUpdateResult(eventType: EventType, dokStatus: UpdateStatusResult) {
+        statusesSuccessfullyUpdatedByType[eventType] = dokStatus.updatedStatuses
+        statusesWithNoChange[eventType] = dokStatus.unchangedStatuses
+        statusesWithoutMatch[eventType] = dokStatus.unmatchedStatuses
+    }
+
+    private fun countStatusesPerProducer(dokStatus: List<DoknotifikasjonStatus>): Map<String, Int> {
+        return dokStatus.groupingBy { it.getBestillerId() }.eachCount()
+    }
+
+    fun timeElapsedSinceSessionStartNanos(): Long {
+        return System.nanoTime() - startTime
+    }
+
+    fun getTotalEventsProcessed() = allStatusesByProducer.values.sum()
+
+    fun getTotalEventsByProducer() = allStatusesByProducer
+
+    fun getCountOfStatuesSuccessfullyUpdated(): List<TagPermutationWithCount> {
+        return statusesSuccessfullyUpdatedByType.map { (eventType, statuses) ->
+            countForEachTagPermutation(eventType.name, statuses)
+        }.flatten()
+    }
+
+    fun getCountOfStatuesWithNoChange(): List<TagPermutationWithCount> {
+        return statusesWithNoChange.map { (eventType, statuses) ->
+            countForEachTagPermutation(eventType.name, statuses)
+        }.flatten()
+    }
+
+    fun getCountOfStatuesWithNoMatch(): List<TagPermutationWithCount> {
+        return statusesWithoutMatch.map { (_, statuses) ->
+            statuses
+        }.reduce { left, right ->
+            left.intersect(right).toList()
+        }.let {
+            countForEachTagPermutation("N/A", it)
+        }
+    }
+
+    private fun countForEachTagPermutation(eventType: String, statuses: List<DoknotifikasjonStatus>): List<TagPermutationWithCount> {
+        return statuses.groupingBy { doknotStatus ->
+            doknotStatus.getBestillerId() to doknotStatus.getStatus()
+        }.eachCount().map { (bestillerStatus, count) ->
+            val (bestiller, status) = bestillerStatus
+
+            TagPermutationWithCount(eventType, bestiller, status, count)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/metrics/TagPermutationWithCount.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/metrics/TagPermutationWithCount.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.metrics
+
+data class TagPermutationWithCount(
+    val eventType: String,
+    val producer: String,
+    val status: String,
+    val count: Int
+)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventService.kt
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 class DoneEventService(
         private val donePersistingService: DonePersistingService,
         private val eventMetricsProbe: EventMetricsProbe
-) : EventBatchProcessorService<DoneIntern> {
+) : EventBatchProcessorService<NokkelIntern, DoneIntern> {
 
     private val log: Logger = LoggerFactory.getLogger(DoneEventService::class.java)
 
@@ -58,12 +58,12 @@ class DoneEventService(
     }
 
     private fun EventMetricsSession.countDuplicateKeyEvents(result: ListPersistActionResult<Done>) {
-        if (result.foundConflictingKeys()) {
+        if (result.foundUnalteredEntitites()) {
 
-            val constraintErrors = result.getConflictingEntities().size
+            val constraintErrors = result.getUnalteredEntities().size
             val totalEntities = result.getAllEntities().size
 
-            result.getConflictingEntities()
+            result.getUnalteredEntities()
                     .groupingBy { done -> Produsent(done.appnavn, done.namespace) }
                     .eachCount()
                     .forEach { (produsent, duplicates) ->

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/doneQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/doneQueries.kt
@@ -32,7 +32,7 @@ private const val createQuery = """INSERT INTO done(systembruker, eventTidspunkt
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 
 fun Connection.createDoneEvents(doneEvents: List<Done>): ListPersistActionResult<Done> =
-    executeBatchPersistQuery(createQuery) {
+    executeBatchPersistQueryIgnoreConflict(createQuery) {
         doneEvents.forEach { done ->
             buildStatementForSingleRow(done)
             addBatch()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/health/HealthService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/health/HealthService.kt
@@ -6,15 +6,16 @@ class HealthService(private val applicationContext: ApplicationContext) {
 
     suspend fun getHealthChecks(): List<HealthStatus> {
         return listOf(
-                applicationContext.database.status(),
-                applicationContext.beskjedConsumer.status(),
-                applicationContext.innboksConsumer.status(),
-                applicationContext.oppgaveConsumer.status(),
-                applicationContext.doneConsumer.status(),
-                applicationContext.statusoppdateringConsumer.status(),
-                applicationContext.periodicDoneEventWaitingTableProcessor.status(),
-                applicationContext.periodicConsumerPollingCheck.status(),
-                applicationContext.periodicExpiredBeskjedProcessor.status()
+            applicationContext.database.status(),
+            applicationContext.beskjedConsumer.status(),
+            applicationContext.innboksConsumer.status(),
+            applicationContext.oppgaveConsumer.status(),
+            applicationContext.doneConsumer.status(),
+            applicationContext.statusoppdateringConsumer.status(),
+            applicationContext.periodicDoneEventWaitingTableProcessor.status(),
+            applicationContext.periodicConsumerPollingCheck.status(),
+            applicationContext.periodicExpiredBeskjedProcessor.status(),
+            applicationContext.doknotifikasjonStatusConsumer.status()
         )
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksEventService.kt
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 class InnboksEventService(
         private val persistingService: BrukernotifikasjonPersistingService<Innboks>,
         private val metricsProbe: EventMetricsProbe
-) : EventBatchProcessorService<InnboksIntern> {
+) : EventBatchProcessorService<NokkelIntern, InnboksIntern> {
 
     private val log = LoggerFactory.getLogger(InnboksEventService::class.java)
 
@@ -47,12 +47,12 @@ class InnboksEventService(
     }
 
     private fun EventMetricsSession.countDuplicateKeyEvents(result: ListPersistActionResult<Innboks>) {
-        if (result.foundConflictingKeys()) {
+        if (result.foundUnalteredEntitites()) {
 
-            val constraintErrors = result.getConflictingEntities().size
+            val constraintErrors = result.getUnalteredEntities().size
             val totalEntities = result.getAllEntities().size
 
-            result.getConflictingEntities()
+            result.getUnalteredEntities()
                     .groupingBy { innboks -> Produsent(innboks.appnavn, innboks.namespace) }
                     .eachCount()
                     .forEach { (produsent, duplicates) ->

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/innboksQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/innboksQueries.kt
@@ -21,7 +21,7 @@ private val createQuery = """INSERT INTO innboks(systembruker, eventTidspunkt, f
             VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 
 fun Connection.createInnboksEventer(innboksEventer: List<Innboks>) =
-        executeBatchPersistQuery(createQuery) {
+        executeBatchPersistQueryIgnoreConflict(createQuery) {
             innboksEventer.forEach { innboks ->
                 buildStatementForSingleRow(innboks)
                 addBatch()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricNames.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricNames.kt
@@ -16,3 +16,9 @@ const val KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER = "$METRIC_NAMESPACE.topic.pro
 const val KAFKA_UNIQUE_EVENTS_ON_TOPIC = "$METRIC_NAMESPACE.topic.aggregated.unique"
 const val KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER = "$METRIC_NAMESPACE.topic.producer.unique"
 const val KAFKA_DUPLICATE_EVENTS_ON_TOPIC = "$METRIC_NAMESPACE.topic.duplicates"
+
+const val KAFKA_DOKNOT_STATUS_TOTAL_PROCESSED = "$METRIC_NAMESPACE.doknot.status.total.processed"
+const val KAFKA_DOKNOT_STATUS_UPDATED = "$METRIC_NAMESPACE.doknot.status.updated"
+const val KAFKA_DOKNOT_STATUS_UNCHANGED = "$METRIC_NAMESPACE.doknot.status.unchanged"
+const val KAFKA_DOKNOT_STATUS_IGNORED = "$METRIC_NAMESPACE.doknot.status.ignored"
+const val KAFKA_DOKNOT_STATUS_BATCH = "$METRIC_NAMESPACE.doknot.status.batch"

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricsProbeSetup.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricsProbeSetup.kt
@@ -5,11 +5,17 @@ import no.nav.personbruker.dittnav.common.metrics.StubMetricsReporter
 import no.nav.personbruker.dittnav.common.metrics.influxdb.InfluxConfig
 import no.nav.personbruker.dittnav.common.metrics.influxdb.InfluxMetricsReporter
 import no.nav.personbruker.dittnav.eventaggregator.config.Environment
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.metrics.DoknotifikasjonStatusMetricsProbe
 import no.nav.personbruker.dittnav.eventaggregator.metrics.db.DBMetricsProbe
 
 fun buildEventMetricsProbe(environment: Environment): EventMetricsProbe {
     val metricsReporter = resolveMetricsReporter(environment)
     return EventMetricsProbe(metricsReporter)
+}
+
+fun buildDoknotifikasjonStatusMetricsProbe(environment: Environment): DoknotifikasjonStatusMetricsProbe {
+    val metricsReporter = resolveMetricsReporter(environment)
+    return DoknotifikasjonStatusMetricsProbe(metricsReporter)
 }
 
 fun buildDBMetricsProbe(environment: Environment): DBMetricsProbe {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveEventService.kt
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 class OppgaveEventService(
         private val persistingService: BrukernotifikasjonPersistingService<Oppgave>,
         private val metricsProbe: EventMetricsProbe
-) : EventBatchProcessorService<OppgaveIntern> {
+) : EventBatchProcessorService<NokkelIntern, OppgaveIntern> {
 
     private val log = LoggerFactory.getLogger(OppgaveEventService::class.java)
 
@@ -47,12 +47,12 @@ class OppgaveEventService(
     }
 
     fun EventMetricsSession.countDuplicateKeyEvents(result: ListPersistActionResult<Oppgave>) {
-        if (result.foundConflictingKeys()) {
+        if (result.foundUnalteredEntitites()) {
 
-            val constraintErrors = result.getConflictingEntities().size
+            val constraintErrors = result.getUnalteredEntities().size
             val totalEntities = result.getAllEntities().size
 
-            result.getConflictingEntities()
+            result.getUnalteredEntities()
                     .groupingBy { oppgave -> Produsent(oppgave.appnavn, oppgave.namespace) }
                     .eachCount()
                     .forEach { (produsent, duplicates) ->

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveRepository.kt
@@ -24,4 +24,9 @@ class OppgaveRepository(private val database: Database) : BrukernotifikasjonRepo
         }
     }
 
+    suspend fun getOppgaveWithEksternVarslingForEventIds(eventIds: List<String>): List<Oppgave> {
+        return database.queryWithExceptionTranslation {
+            getOppgaveWithEksternVarslingForEventIds(eventIds)
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringEventService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringEventService.kt
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory
 class StatusoppdateringEventService(
         private val persistingService: BrukernotifikasjonPersistingService<Statusoppdatering>,
         private val metricsProbe: EventMetricsProbe
-) : EventBatchProcessorService<StatusoppdateringIntern> {
+) : EventBatchProcessorService<NokkelIntern, StatusoppdateringIntern> {
 
     private val log: Logger = LoggerFactory.getLogger(StatusoppdateringEventService::class.java)
 
@@ -48,12 +48,12 @@ class StatusoppdateringEventService(
     }
 
     private fun EventMetricsSession.countDuplicateKeyEvents(result: ListPersistActionResult<Statusoppdatering>) {
-        if (result.foundConflictingKeys()) {
+        if (result.foundUnalteredEntitites()) {
 
-            val constraintErrors = result.getConflictingEntities().size
+            val constraintErrors = result.getUnalteredEntities().size
             val totalEntities = result.getAllEntities().size
 
-            result.getConflictingEntities()
+            result.getUnalteredEntities()
                     .groupingBy { statusoppdatering -> Produsent(statusoppdatering.appnavn, statusoppdatering.namespace)}
                     .eachCount()
                     .forEach { (produsent, duplicates) ->

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/statusoppdateringQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/statusoppdateringQueries.kt
@@ -17,7 +17,7 @@ fun Connection.createStatusoppdatering(statusoppdatering: Statusoppdatering): Pe
         }
 
 fun Connection.createStatusoppdateringer(statusoppdateringer: List<Statusoppdatering>): ListPersistActionResult<Statusoppdatering> =
-        executeBatchPersistQuery(createQuery) {
+        executeBatchPersistQueryIgnoreConflict(createQuery) {
             statusoppdateringer.forEach { statusoppdatering ->
                 buildStatementForSingleRow(statusoppdatering)
                 addBatch()

--- a/src/main/resources/db/migration/V1.1.24__Legger_til_doknotifikasjon_status.sql
+++ b/src/main/resources/db/migration/V1.1.24__Legger_til_doknotifikasjon_status.sql
@@ -1,7 +1,7 @@
 CREATE TABLE doknotifikasjon_status_beskjed (
     eventId VARCHAR(50) UNIQUE,
-    status VARCHAR(25),
-    melding VARCHAR(120),
+    status TEXT,
+    melding TEXT,
     distribusjonsId BIGINT,
     tidspunkt TIMESTAMP WITHOUT TIME ZONE,
     antall_oppdateringer SMALLINT,
@@ -10,8 +10,8 @@ CREATE TABLE doknotifikasjon_status_beskjed (
 
 CREATE TABLE doknotifikasjon_status_oppgave (
     eventId VARCHAR(50) UNIQUE,
-    status VARCHAR(25),
-    melding VARCHAR(120),
+    status TEXT,
+    melding TEXT,
     distribusjonsId BIGINT,
     tidspunkt TIMESTAMP WITHOUT TIME ZONE,
     antall_oppdateringer SMALLINT,

--- a/src/main/resources/db/migration/V1.1.24__Legger_til_doknotifikasjon_status.sql
+++ b/src/main/resources/db/migration/V1.1.24__Legger_til_doknotifikasjon_status.sql
@@ -1,0 +1,19 @@
+CREATE TABLE doknotifikasjon_status_beskjed (
+    eventId VARCHAR(50) UNIQUE,
+    status VARCHAR(25),
+    melding VARCHAR(120),
+    distribusjonsId BIGINT,
+    tidspunkt TIMESTAMP WITHOUT TIME ZONE,
+    antall_oppdateringer SMALLINT,
+    constraint fk_dokstatus_beskjed_eventid FOREIGN KEY(eventId) REFERENCES beskjed(eventId)
+);
+
+CREATE TABLE doknotifikasjon_status_oppgave (
+    eventId VARCHAR(50) UNIQUE,
+    status VARCHAR(25),
+    melding VARCHAR(120),
+    distribusjonsId BIGINT,
+    tidspunkt TIMESTAMP WITHOUT TIME ZONE,
+    antall_oppdateringer SMALLINT,
+    constraint fk_dokstatus_oppgave_eventid FOREIGN KEY(eventId) REFERENCES oppgave(eventId)
+);

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedIT.kt
@@ -8,6 +8,7 @@ import no.nav.personbruker.dittnav.common.metrics.StubMetricsReporter
 import no.nav.personbruker.dittnav.eventaggregator.common.database.BrukernotifikasjonPersistingService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.LocalPostgresDatabase
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.Consumer
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createBeskjedRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createEventRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.delayUntilCommittedOffset
 import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsProbe
@@ -35,7 +36,7 @@ class BeskjedIT {
 
     @Test
     fun `Skal lese inn Beskjed-eventer og skrive de til databasen`() {
-        val beskjeder = createEventRecords(10, beskjedTopicPartition, AvroBeskjedObjectMother::createBeskjed)
+        val beskjeder = createBeskjedRecords(10, beskjedTopicPartition)
         beskjeder.forEach { beskjedConsumerMock.addRecord(it) }
 
         runBlocking {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedObjectMother.kt
@@ -50,6 +50,13 @@ object BeskjedObjectMother {
         return beskjed.copy(eksternVarsling = eksternVarsling, prefererteKanaler = prefererteKanaler)
     }
 
+    fun giveMeBeskjedWithEventIdAndAppnavn(eventId: String, appnavn: String): Beskjed {
+        return giveMeBeskjed(
+            eventId = eventId,
+            appnavn = appnavn
+        )
+    }
+
     private fun giveMeBeskjed(
             systembruker: String = defaultSystembruker,
             namespace: String = defaultNamespace,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedRepositoryTest.kt
@@ -59,7 +59,7 @@ class BeskjedRepositoryTest {
             val result = beskjedRepository.createInOneBatch(toCreate)
 
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 
@@ -75,7 +75,7 @@ class BeskjedRepositoryTest {
             val result = beskjedRepository.createOneByOneToFilterOutTheProblematicEvents(toCreate)
 
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/SimpleEventCounterService.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/SimpleEventCounterService.kt
@@ -3,9 +3,9 @@ package no.nav.personbruker.dittnav.eventaggregator.common
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import org.apache.kafka.clients.consumer.ConsumerRecords
 
-class SimpleEventCounterService<T>(var eventCounter: Int = 0) : EventBatchProcessorService<T> {
+class SimpleEventCounterService<K,  V>(var eventCounter: Int = 0) : EventBatchProcessorService<K, V> {
 
-    override suspend fun processEvents(events: ConsumerRecords<NokkelIntern, T>) {
+    override suspend fun processEvents(events: ConsumerRecords<K, V>) {
         eventCounter += events.count()
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/ThrowingEventCounterService.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/ThrowingEventCounterService.kt
@@ -3,15 +3,15 @@ package no.nav.personbruker.dittnav.eventaggregator.common
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import org.apache.kafka.clients.consumer.ConsumerRecords
 
-class ThrowingEventCounterService<T>(val exception: Exception? = null, val every: Int = 1) :
-    EventBatchProcessorService<T> {
+class ThrowingEventCounterService<V>(val exception: Exception? = null, val every: Int = 1) :
+    EventBatchProcessorService<NokkelIntern, V> {
 
     var invocationCounter = 0
     val successfulEventsCounter get() = successfulEvents.size
 
-    val successfulEvents = mutableListOf<T>()
+    val successfulEvents = mutableListOf<V>()
 
-    override suspend fun processEvents(events: ConsumerRecords<NokkelIntern, T>) {
+    override suspend fun processEvents(events: ConsumerRecords<NokkelIntern, V>) {
         events.forEach {
             invocationCounter++
             if (exception != null && invocationCounter % every == 0) {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/MultipleTopicsConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/MultipleTopicsConsumerTest.kt
@@ -8,8 +8,10 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.brukernotifikasjon.schemas.internal.OppgaveIntern
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.common.SimpleEventCounterService
-import no.nav.personbruker.dittnav.eventaggregator.common.kafka.Consumer
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.*
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createBeskjedRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createEventRecords
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createOppgaveRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.delayUntilDone
 import no.nav.personbruker.dittnav.eventaggregator.innboks.AvroInnboksObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.oppgave.AvroOppgaveObjectMother
@@ -20,9 +22,9 @@ import org.junit.jupiter.api.Test
 
 class MultipleTopicsConsumerTest {
 
-    private val beskjedProcessor = SimpleEventCounterService<BeskjedIntern>()
-    private val oppgaveProcessor = SimpleEventCounterService<OppgaveIntern>()
-    private val innboksProcessor = SimpleEventCounterService<InnboksIntern>()
+    private val beskjedProcessor = SimpleEventCounterService<NokkelIntern, BeskjedIntern>()
+    private val oppgaveProcessor = SimpleEventCounterService<NokkelIntern, OppgaveIntern>()
+    private val innboksProcessor = SimpleEventCounterService<NokkelIntern, InnboksIntern>()
 
     private val beskjedTopicPartition = TopicPartition("beskjed", 0)
     private val oppgaveTopicPartition = TopicPartition("oppgave", 0)
@@ -52,9 +54,9 @@ class MultipleTopicsConsumerTest {
 
     @Test
     fun `Skal kunne konsumere fra flere topics i parallell 2`() {
-        val beskjeder = createEventRecords(4, beskjedTopicPartition, AvroBeskjedObjectMother::createBeskjed)
-        val oppgaver = createEventRecords(5, oppgaveTopicPartition, AvroOppgaveObjectMother::createOppgave)
-        val innbokser = createEventRecords(6, innboksTopicPartition, AvroInnboksObjectMother::createInnboks)
+        val beskjeder = createBeskjedRecords(4, beskjedTopicPartition)
+        val oppgaver = createOppgaveRecords(5, oppgaveTopicPartition)
+        val innbokser = createInnboksRecords(6, innboksTopicPartition)
 
         runBlocking {
             beskjedConsumer.startPolling()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/SingleTopicConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/kafka/consumer/SingleTopicConsumerTest.kt
@@ -7,6 +7,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.common.SimpleEventCounterService
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.Consumer
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createBeskjedRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createEventRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.delayUntilDone
 import org.apache.kafka.clients.consumer.MockConsumer
@@ -19,7 +20,7 @@ class SingleTopicConsumerTest {
     @Test
     fun `Lese inn alle testeventene fra Kafka`() {
 
-        val eventProcessor = SimpleEventCounterService<BeskjedIntern>()
+        val eventProcessor = SimpleEventCounterService<NokkelIntern, BeskjedIntern>()
         val topicPartition = TopicPartition("topic", 0)
         val consumerMock = MockConsumer<NokkelIntern, BeskjedIntern>(OffsetResetStrategy.EARLIEST).also {
             it.subscribe(listOf(topicPartition.topic()))
@@ -28,7 +29,7 @@ class SingleTopicConsumerTest {
         }
         val consumer = Consumer(topicPartition.topic(), consumerMock, eventProcessor)
 
-        val events = createEventRecords(10, topicPartition, AvroBeskjedObjectMother::createBeskjed)
+        val events = createBeskjedRecords(10, topicPartition)
 
         runBlocking {
             consumer.startPolling()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTest.kt
@@ -28,7 +28,7 @@ import java.time.Duration
 class ConsumerTest {
 
     private val kafkaConsumer = mockk<KafkaConsumer<NokkelIntern, BeskjedIntern>>(relaxUnitFun = true)
-    private val eventBatchProcessorService = mockk<EventBatchProcessorService<BeskjedIntern>>(relaxed = true)
+    private val eventBatchProcessorService = mockk<EventBatchProcessorService<NokkelIntern, BeskjedIntern>>(relaxed = true)
 
     companion object {
         private const val defaultMaxPollTimeout: Long = 5000
@@ -53,7 +53,7 @@ class ConsumerTest {
         val topic = "dummyTopicNoErrors"
         every { kafkaConsumer.poll(any<Duration>()) } returns ConsumerRecordsObjectMother.giveMeANumberOfBeskjedRecords(1, topic)
 
-        val consumer: Consumer<BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
+        val consumer: Consumer<NokkelIntern, BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
 
         runBlocking {
             consumer.startPolling()
@@ -71,7 +71,7 @@ class ConsumerTest {
         every { kafkaConsumer.poll(any<Duration>()) } returns ConsumerRecordsObjectMother.giveMeANumberOfBeskjedRecords(1, topic)
         coEvery { eventBatchProcessorService.processEvents(any()) } throws Exception("Simulert feil i en test")
 
-        val consumer: Consumer<BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
+        val consumer: Consumer<NokkelIntern, BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
 
         runBlocking {
             consumer.startPolling()
@@ -87,7 +87,7 @@ class ConsumerTest {
         every { kafkaConsumer.poll(any<Duration>()) } returns ConsumerRecordsObjectMother.giveMeANumberOfBeskjedRecords(1, topic)
         coEvery { eventBatchProcessorService.processEvents(any()) } throws UnretriableDatabaseException("Simulert feil i en test")
 
-        val consumer: Consumer<BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
+        val consumer: Consumer<NokkelIntern, BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
 
         runBlocking {
             consumer.startPolling()
@@ -103,7 +103,7 @@ class ConsumerTest {
         every { kafkaConsumer.poll(any<Duration>()) } returns ConsumerRecordsObjectMother.giveMeANumberOfBeskjedRecords(1, topic)
         coEvery { eventBatchProcessorService.processEvents(any()) } throws UntransformableRecordException("Simulert feil i en test")
 
-        val consumer: Consumer<BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
+        val consumer: Consumer<NokkelIntern, BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
 
         runBlocking {
             consumer.startPolling()
@@ -118,7 +118,7 @@ class ConsumerTest {
         val topic = "dummyTopicKafkaRetriable"
         val retriableKafkaException = DisconnectException("Simulert feil i en test")
         every { kafkaConsumer.poll(any<Duration>()) } throws retriableKafkaException
-        val consumer: Consumer<BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
+        val consumer: Consumer<NokkelIntern, BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
         every { kafkaConsumer.rollbackToLastCommitted() } returns Unit
 
         runBlocking {
@@ -138,7 +138,7 @@ class ConsumerTest {
         every { kafkaConsumer.poll(any<Duration>()) } returns ConsumerRecordsObjectMother.giveMeANumberOfBeskjedRecords(1, topic)
         val retriableDbExption = RetriableDatabaseException("Simulert feil i en test")
         coEvery { eventBatchProcessorService.processEvents(any()) } throws retriableDbExption
-        val consumer: Consumer<BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
+        val consumer: Consumer<NokkelIntern, BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
         every { kafkaConsumer.rollbackToLastCommitted() } returns Unit
 
 
@@ -158,7 +158,7 @@ class ConsumerTest {
         val topic = "dummyTopicNoRecordsFound"
         every { kafkaConsumer.poll(any<Duration>()) } returns ConsumerRecordsObjectMother.giveMeANumberOfBeskjedRecords(0, topic)
 
-        val consumer: Consumer<BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
+        val consumer: Consumer<NokkelIntern, BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
 
         runBlocking {
             consumer.startPolling()
@@ -174,7 +174,7 @@ class ConsumerTest {
         val topic = "dummyTopicCancellationException"
         val cancellationException = CancellationException("Simulert feil i en test")
         every { kafkaConsumer.poll(any<Duration>()) } throws cancellationException
-        val consumer: Consumer<BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
+        val consumer: Consumer<NokkelIntern, BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
 
         runBlocking {
             consumer.startPolling()
@@ -187,7 +187,7 @@ class ConsumerTest {
         val topic = "dummyTopicTopicAuthorizationException"
         val topicAuthorizationException = TopicAuthorizationException("Simulert feil i en test")
         every { kafkaConsumer.poll(any<Duration>()) } throws topicAuthorizationException
-        val consumer: Consumer<BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
+        val consumer: Consumer<NokkelIntern, BeskjedIntern> = Consumer(topic, kafkaConsumer, eventBatchProcessorService, maxPollTimeout = defaultMaxPollTimeout)
 
         runBlocking {
             consumer.startPolling()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTestIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/kafka/ConsumerTestIT.kt
@@ -35,7 +35,7 @@ class ConsumerTestIT {
         val eventProcessor = ThrowingEventCounterService<BeskjedIntern>()
         val beskjedConsumer = Consumer(topicPartition.topic(), consumerMock, eventProcessor)
 
-        val beskjeder = createEventRecords(10, topicPartition, AvroBeskjedObjectMother::createBeskjed)
+        val beskjeder = createBeskjedRecords(10, topicPartition)
 
         runBlocking {
             beskjedConsumer.startPolling()
@@ -57,7 +57,7 @@ class ConsumerTestIT {
             it.updateBeginningOffsets(mapOf(topicPartition to 0))
         }
 
-        val beskjeder = createEventRecords(3, topicPartition, AvroBeskjedObjectMother::createBeskjed)
+        val beskjeder = createBeskjedRecords(3, topicPartition)
 
         val eventProcessor = ThrowingEventCounterService<BeskjedIntern>(RetriableDatabaseException("Transient error"), 2)
         val beskjedConsumer = Consumer(topicPartition.topic(), consumerMock, eventProcessor)
@@ -86,7 +86,7 @@ class ConsumerTestIT {
         val eventProcessor = ThrowingEventCounterService<BeskjedIntern>(UnretriableDatabaseException("Fatal error"), 3)
         val beskjedConsumer = Consumer(topicPartition.topic(), consumerMock, eventProcessor)
 
-        val beskjeder = createEventRecords(5, topicPartition, AvroBeskjedObjectMother::createBeskjed)
+        val beskjeder = createBeskjedRecords(5, topicPartition)
         runBlocking {
             beskjedConsumer.startPolling()
             beskjeder.forEach { consumerMock.addRecord(it) }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/objectmother/ConsumerRecordsObjectMother.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.dittnav.eventaggregator.common.objectmother
 
 import no.nav.brukernotifikasjon.schemas.internal.*
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.AvroBeskjedObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.innboks.AvroInnboksObjectMother
 import no.nav.personbruker.dittnav.eventaggregator.nokkel.AvroNokkelInternObjectMother
@@ -81,13 +82,21 @@ object ConsumerRecordsObjectMother {
         return allRecords
     }
 
-    fun wrapInConsumerRecords(recordsForSingleTopic: List<ConsumerRecord<NokkelIntern, DoneIntern>>, topicName: String = "dummyTopic"): ConsumerRecords<NokkelIntern, DoneIntern> {
-        val records = mutableMapOf<TopicPartition, List<ConsumerRecord<NokkelIntern, DoneIntern>>>()
+    fun <K, V> wrapInConsumerRecords(recordsForSingleTopic: List<ConsumerRecord<K, V>>, topicName: String): ConsumerRecords<K, V> {
+        val records = mutableMapOf<TopicPartition, List<ConsumerRecord<K, V>>>()
         records[TopicPartition(topicName, 1)] = recordsForSingleTopic
         return ConsumerRecords(records)
     }
 
     fun wrapInConsumerRecords(singleRecord: ConsumerRecord<NokkelIntern, DoneIntern>): ConsumerRecords<NokkelIntern, DoneIntern> {
-        return wrapInConsumerRecords(listOf(singleRecord))
+        return wrapInConsumerRecords(listOf(singleRecord), singleRecord.topic())
+    }
+
+    fun doknotStatusesAsConsumerRecords(doknotStatuses: List<DoknotifikasjonStatus>, topicName: String): ConsumerRecords<String, DoknotifikasjonStatus> {
+        return doknotStatuses.mapIndexed { index, status ->
+            ConsumerRecord(topicName, 1, index.toLong(), status.getBestillingsId(), status)
+        }.let {
+            wrapInConsumerRecords(it, topicName)
+        }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/persistActionResultMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/persistActionResultMother.kt
@@ -1,14 +1,28 @@
 package no.nav.personbruker.dittnav.eventaggregator.common
 
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.common.database.PersistFailureReason
+import no.nav.personbruker.dittnav.eventaggregator.common.database.PersistOutcome
 
 fun <T> successfulEvents(events: List<T>): ListPersistActionResult<T> {
     return events.map{ event ->
-        event to PersistFailureReason.NO_ERROR
+        event to PersistOutcome.SUCCESS
     }.let { entryList ->
         ListPersistActionResult.mapListOfIndividualResults(entryList)
     }
 }
 
 fun <T> emptyPersistResult(): ListPersistActionResult<T> = ListPersistActionResult.mapListOfIndividualResults(emptyList())
+
+fun <T> createPersistActionResult(successful: List<T>, unchanged: List<T>): ListPersistActionResult<T> {
+    val successfulPart = successful.map { entry ->
+        entry to PersistOutcome.SUCCESS
+    }
+
+    val unchangedPart = unchanged.map { entry ->
+        entry to PersistOutcome.NO_INSERT_OR_UPDATE
+    }
+
+    return (successfulPart + unchangedPart).let {
+        ListPersistActionResult.mapListOfIndividualResults(it)
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotStatusDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotStatusDTO.kt
@@ -1,0 +1,12 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import java.time.LocalDateTime
+
+data class DoknotStatusDTO(
+    val eventId: String,
+    val status: String,
+    val melding: String,
+    val distribusjonsId: Long,
+    val antallOppdateringer: Int,
+    val tidspunkt: LocalDateTime
+)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusObjectMother.kt
@@ -1,0 +1,28 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
+
+object DoknotifikasjonStatusObjectMother {
+
+    private val defaultBestiller = "dummyBestiller"
+    private val defaultStatus = "INFO"
+    private val defaultMelding = "dummyMelding"
+    private val defaultDistribusjonsId = 1L
+
+    fun createDoknotifikasjonStatus(
+        bestillingsId: String,
+        bestiller: String = defaultBestiller,
+        status: String = defaultStatus,
+        melding: String = defaultMelding,
+        distribusjonsId: Long = defaultDistribusjonsId
+    ): DoknotifikasjonStatus {
+        return DoknotifikasjonStatus.newBuilder()
+                .setBestillingsId(bestillingsId)
+                .setBestillerId(bestiller)
+                .setStatus(status)
+                .setMelding(melding)
+                .setDistribusjonId(distribusjonsId)
+                .build()
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusQueryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusQueryTest.kt
@@ -1,0 +1,222 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.Beskjed
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.createBeskjed
+import no.nav.personbruker.dittnav.eventaggregator.common.database.LocalPostgresDatabase
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.Oppgave
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.createOppgave
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+internal class DoknotifikasjonStatusQueryTest {
+
+    private val database = LocalPostgresDatabase.migratedDb()
+
+    private val beskjed: Beskjed
+    private val oppgave: Oppgave
+
+    private val bestillingsIdBeskjed: String
+    private val bestillingsIdOppgave: String
+
+    init {
+        beskjed = createBeskjedInDb()
+        oppgave = createOppgaveInDb()
+
+        bestillingsIdBeskjed = beskjed.eventId
+        bestillingsIdOppgave = oppgave.eventId
+    }
+
+    @AfterEach
+    fun cleanDatabase() {
+        runBlocking {
+            database.dbQuery {
+                deleteAllDoknotifikasjonStatusBeskjed()
+                deleteAllDoknotifikasjonStatusOppgave()
+            }
+        }
+    }
+
+    @Test
+    fun `should create insert new status for beskjed when none exists for eventId`() = runBlocking {
+        val statusUpdate = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdBeskjed)
+
+        val persistResult = database.dbQuery {
+            upsertDoknotifikasjonStatusForBeskjed(listOf(statusUpdate))
+        }
+
+        val allStatuses = database.dbQuery {
+            getAllDoknotifikasjonBeskjed()
+        }
+
+        allStatuses.size shouldBe 1
+
+        allStatuses[0].eventId shouldBe statusUpdate.getBestillingsId()
+        allStatuses[0].status shouldBe statusUpdate.getStatus()
+        allStatuses[0].melding shouldBe statusUpdate.getMelding()
+        allStatuses[0].distribusjonsId shouldBe statusUpdate.getDistribusjonId()
+        allStatuses[0].antallOppdateringer shouldBe 1
+
+        persistResult.allEntitiesPersisted() shouldBe true
+        persistResult.getPersistedEntitites() shouldContain statusUpdate
+    }
+
+    @Test
+    fun `should update status for beskjed when one already exists for eventId`() = runBlocking {
+        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdBeskjed)
+
+        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(
+            bestillingsId = bestillingsIdBeskjed,
+            status = "new status",
+            melding = "new melding",
+            distribusjonsId = 321
+        )
+
+        val persistResult = database.dbQuery {
+            upsertDoknotifikasjonStatusForBeskjed(listOf(statusUpdate1, statusUpdate2))
+        }
+
+        val allStatuses = database.dbQuery {
+            getAllDoknotifikasjonBeskjed()
+        }
+
+        allStatuses.size shouldBe 1
+
+        allStatuses[0].eventId shouldBe statusUpdate2.getBestillingsId()
+        allStatuses[0].status shouldBe statusUpdate2.getStatus()
+        allStatuses[0].melding shouldBe statusUpdate2.getMelding()
+        allStatuses[0].distribusjonsId shouldBe statusUpdate2.getDistribusjonId()
+        allStatuses[0].antallOppdateringer shouldBe 2
+
+
+        persistResult.allEntitiesPersisted() shouldBe true
+        persistResult.getPersistedEntitites() shouldContain statusUpdate1
+        persistResult.getPersistedEntitites() shouldContain statusUpdate2
+    }
+
+    @Test
+    fun `should not make any changes for identical status updates for beskjed`() = runBlocking {
+        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdBeskjed)
+        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdBeskjed)
+
+        val persistResult = database.dbQuery {
+            upsertDoknotifikasjonStatusForBeskjed(listOf(statusUpdate1, statusUpdate2))
+        }
+
+        val allStatuses = database.dbQuery {
+            getAllDoknotifikasjonBeskjed()
+        }
+
+        allStatuses.size shouldBe 1
+
+        allStatuses[0].antallOppdateringer shouldBe 1
+
+        persistResult.allEntitiesPersisted() shouldBe false
+        persistResult.getPersistedEntitites() shouldContain statusUpdate1
+        persistResult.getUnalteredEntities() shouldContain statusUpdate2
+    }
+
+    @Test
+    fun `should create insert new status for oppgave when none exists for eventId`() = runBlocking {
+        val statusUpdate = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdOppgave)
+
+        val persistResult = database.dbQuery {
+            upsertDoknotifikasjonStatusForOppgave(listOf(statusUpdate))
+        }
+
+        val allStatuses = database.dbQuery {
+            getAllDoknotifikasjonOppgave()
+        }
+
+        allStatuses.size shouldBe 1
+
+        allStatuses[0].eventId shouldBe statusUpdate.getBestillingsId()
+        allStatuses[0].status shouldBe statusUpdate.getStatus()
+        allStatuses[0].melding shouldBe statusUpdate.getMelding()
+        allStatuses[0].distribusjonsId shouldBe statusUpdate.getDistribusjonId()
+        allStatuses[0].antallOppdateringer shouldBe 1
+
+        persistResult.allEntitiesPersisted() shouldBe true
+        persistResult.getPersistedEntitites() shouldContain statusUpdate
+    }
+
+    @Test
+    fun `should update status for oppgave when one already exists for eventId`() = runBlocking {
+        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdOppgave)
+
+        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(
+            bestillingsId = bestillingsIdOppgave,
+            status = "new status",
+            melding = "new melding",
+            distribusjonsId = 321
+        )
+
+        val persistResult = database.dbQuery {
+            upsertDoknotifikasjonStatusForOppgave(listOf(statusUpdate1, statusUpdate2))
+        }
+
+        val allStatuses = database.dbQuery {
+            getAllDoknotifikasjonOppgave()
+        }
+
+        allStatuses.size shouldBe 1
+
+        allStatuses[0].eventId shouldBe statusUpdate2.getBestillingsId()
+        allStatuses[0].status shouldBe statusUpdate2.getStatus()
+        allStatuses[0].melding shouldBe statusUpdate2.getMelding()
+        allStatuses[0].distribusjonsId shouldBe statusUpdate2.getDistribusjonId()
+        allStatuses[0].antallOppdateringer shouldBe 2
+
+        persistResult.allEntitiesPersisted() shouldBe true
+        persistResult.getPersistedEntitites() shouldContain statusUpdate1
+        persistResult.getPersistedEntitites() shouldContain statusUpdate2
+    }
+
+    @Test
+    fun `should not make any changes for identical status updates for oppgave`() = runBlocking {
+        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdOppgave)
+        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdOppgave)
+
+        val persistResult = database.dbQuery {
+            upsertDoknotifikasjonStatusForOppgave(listOf(statusUpdate1, statusUpdate2))
+        }
+
+        val allStatuses = database.dbQuery {
+            getAllDoknotifikasjonOppgave()
+        }
+
+        allStatuses.size shouldBe 1
+
+        allStatuses[0].antallOppdateringer shouldBe 1
+
+        persistResult.allEntitiesPersisted() shouldBe false
+        persistResult.getPersistedEntitites() shouldContain statusUpdate1
+        persistResult.getUnalteredEntities() shouldContain statusUpdate2
+    }
+
+    private fun createBeskjedInDb(): Beskjed {
+        val beskjed = BeskjedObjectMother.giveMeAktivBeskjed()
+        return runBlocking {
+            database.dbQuery {
+                createBeskjed(beskjed).entityId.let {
+                    beskjed.copy(id = it)
+                }
+            }
+        }
+    }
+
+    private fun createOppgaveInDb(): Oppgave {
+        val oppgave = OppgaveObjectMother.giveMeAktivOppgave()
+        return runBlocking {
+            database.dbQuery {
+                createOppgave(oppgave).entityId.let {
+                    oppgave.copy(id = it)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusServiceTest.kt
@@ -1,0 +1,69 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventaggregator.common.objectmother.ConsumerRecordsObjectMother
+import no.nav.personbruker.dittnav.eventaggregator.config.EventType
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.metrics.DoknotifikasjonStatusMetricsProbe
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.metrics.DoknotifikasjonStatusMetricsSession
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class DoknotifikasjonStatusServiceTest {
+
+    private val metricsSession: DoknotifikasjonStatusMetricsSession = mockk()
+    private val metricsProbe: DoknotifikasjonStatusMetricsProbe = mockk()
+    private val statusUpdater: DoknotifikasjonStatusUpdater = mockk()
+
+    private val doknotifikasjonStatusService = DoknotifikasjonStatusService(statusUpdater, metricsProbe)
+
+    private val statusMatchingBeskjed = createDoknotifikasjonStatus("beskjed")
+    private val statusMatchingOppgave = createDoknotifikasjonStatus("oppgave")
+    private val statusMatchingNone = createDoknotifikasjonStatus("none")
+
+    private val allStatuses = listOf(statusMatchingBeskjed, statusMatchingOppgave, statusMatchingNone)
+    private val statusEvents = ConsumerRecordsObjectMother.doknotStatusesAsConsumerRecords(allStatuses, "doknot")
+
+    @BeforeEach
+    fun setupMocks() {
+        val block = slot<suspend DoknotifikasjonStatusMetricsSession.() -> Unit>()
+
+        coEvery {
+            metricsProbe.runWithMetrics(capture(block))
+        } coAnswers {
+            block.captured(metricsSession)
+        }
+
+        every {
+            metricsSession.countStatuses(any())
+        } returns Unit
+
+        every {
+            metricsSession.recordUpdateResult(any(), any())
+        } returns Unit
+    }
+
+    @Test
+    fun `should process status-events and report number updated for each type`() {
+
+        val updateResultBeskjed: UpdateStatusResult = mockk()
+        val updateResultOppgave: UpdateStatusResult = mockk()
+
+        coEvery {
+            statusUpdater.updateStatusForBeskjed(allStatuses)
+        } returns updateResultBeskjed
+
+        coEvery {
+            statusUpdater.updateStatusForOppgave(allStatuses)
+        } returns updateResultOppgave
+
+        runBlocking {
+            doknotifikasjonStatusService.processEvents(statusEvents)
+        }
+
+        verify(exactly = 1) { metricsSession.countStatuses(allStatuses) }
+        verify(exactly = 1) { metricsSession.recordUpdateResult(EventType.BESKJED_INTERN, updateResultBeskjed) }
+        verify(exactly = 1) { metricsSession.recordUpdateResult(EventType.OPPGAVE_INTERN, updateResultOppgave) }
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusUpdaterTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusUpdaterTest.kt
@@ -1,0 +1,164 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother.giveMeBeskjedWithEventIdAndAppnavn
+import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedRepository
+import no.nav.personbruker.dittnav.eventaggregator.common.createPersistActionResult
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveObjectMother.giveMeOppgaveWithEventIdAndAppnavn
+import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveRepository
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+internal class DoknotifikasjonStatusUpdaterTest {
+
+    private val beskjedRepository: BeskjedRepository = mockk()
+    private val oppgaveRepository: OppgaveRepository = mockk()
+    private val doknotStatusRepository: DoknotifikasjonStatusRepository = mockk()
+
+    private val statusUpdater = DoknotifikasjonStatusUpdater(beskjedRepository, oppgaveRepository, doknotStatusRepository)
+
+    private val status1 = createDoknotifikasjonStatus("status-1")
+    private val status2 = createDoknotifikasjonStatus("status-2")
+    private val status3 = createDoknotifikasjonStatus("status-3")
+
+    private val statuses = listOf(status1, status2, status3)
+
+    @AfterEach
+    fun cleanUp() {
+        clearMocks(beskjedRepository, oppgaveRepository, doknotStatusRepository)
+    }
+
+    @Test
+    fun `should attempt to match statuses with existing beskjed events and update`() {
+        val beskjed1 = giveMeBeskjedWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
+        val beskjed2 = giveMeBeskjedWithEventIdAndAppnavn(status2.getBestillingsId(), status2.getBestillerId())
+
+        coEvery {
+            beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any())
+        } returns listOf(beskjed1, beskjed2)
+
+        val persistResult = createPersistActionResult(
+            successful = listOf(status1),
+            unchanged = listOf(status2)
+        )
+
+        coEvery {
+            doknotStatusRepository.updateStatusesForBeskjed(listOf(status1, status2))
+        } returns persistResult
+
+        val result = runBlocking {
+            statusUpdater.updateStatusForBeskjed(statuses)
+        }
+
+        result.updatedStatuses shouldContain status1
+        result.unchangedStatuses shouldContain status2
+        result.unmatchedStatuses shouldContain status3
+
+        coVerify(exactly = 1) { beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any()) }
+        coVerify(exactly = 1) { doknotStatusRepository.updateStatusesForBeskjed(any()) }
+        coVerify(exactly = 0) { oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any()) }
+    }
+
+    @Test
+    fun `should not consider status to match beskjed if appnavn differs from bestillingsId`() {
+        val beskjed1 = giveMeBeskjedWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
+        val beskjed2 = giveMeBeskjedWithEventIdAndAppnavn(status2.getBestillingsId(), "other")
+
+        coEvery {
+            beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any())
+        } returns listOf(beskjed1, beskjed2)
+
+        val persistResult = createPersistActionResult(
+            successful = listOf(status1),
+            unchanged = emptyList()
+        )
+
+        coEvery {
+            doknotStatusRepository.updateStatusesForBeskjed(listOf(status1))
+        } returns persistResult
+
+        val result = runBlocking {
+            statusUpdater.updateStatusForBeskjed(statuses)
+        }
+
+        result.updatedStatuses shouldContain status1
+        result.unchangedStatuses.isEmpty() shouldBe true
+        result.unmatchedStatuses shouldContainAll listOf(status2, status3)
+
+        coVerify(exactly = 1) { beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any()) }
+        coVerify(exactly = 1) { doknotStatusRepository.updateStatusesForBeskjed(any()) }
+        coVerify(exactly = 0) { oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any()) }
+    }
+
+
+    @Test
+    fun `should attempt to match statuses with existing oppgave events and update`() {
+        val oppgave1 = giveMeOppgaveWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
+        val oppgave2 = giveMeOppgaveWithEventIdAndAppnavn(status2.getBestillingsId(), status2.getBestillerId())
+
+        coEvery {
+            oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any())
+        } returns listOf(oppgave1, oppgave2)
+
+        val persistResult = createPersistActionResult(
+            successful = listOf(status1),
+            unchanged = listOf(status2)
+        )
+
+        coEvery {
+            doknotStatusRepository.updateStatusesForOppgave(listOf(status1, status2))
+        } returns persistResult
+
+        val result = runBlocking {
+            statusUpdater.updateStatusForOppgave(statuses)
+        }
+
+        result.updatedStatuses shouldContain status1
+        result.unchangedStatuses shouldContain status2
+        result.unmatchedStatuses shouldContain status3
+
+        coVerify(exactly = 1) { oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any()) }
+        coVerify(exactly = 1) { doknotStatusRepository.updateStatusesForOppgave(any()) }
+        coVerify(exactly = 0) { beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any()) }
+    }
+
+    @Test
+    fun `should not consider status to match oppgave if appnavn differs from bestillingsId`() {
+        val oppgave1 = giveMeOppgaveWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
+        val oppgave2 = giveMeOppgaveWithEventIdAndAppnavn(status2.getBestillingsId(), "other")
+
+        coEvery {
+            oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any())
+        } returns listOf(oppgave1, oppgave2)
+
+        val persistResult = createPersistActionResult(
+            successful = listOf(status1),
+            unchanged = emptyList()
+        )
+
+        coEvery {
+            doknotStatusRepository.updateStatusesForOppgave(listOf(status1))
+        } returns persistResult
+
+        val result = runBlocking {
+            statusUpdater.updateStatusForOppgave(statuses)
+        }
+
+        result.updatedStatuses shouldContain status1
+        result.unchangedStatuses.isEmpty() shouldBe true
+        result.unmatchedStatuses shouldContainAll listOf(status2, status3)
+
+        coVerify(exactly = 1) { oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any()) }
+        coVerify(exactly = 1) { doknotStatusRepository.updateStatusesForOppgave(any()) }
+        coVerify(exactly = 0) { beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any()) }
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/testDoknotifikasjonStatusQueries.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/testDoknotifikasjonStatusQueries.kt
@@ -1,0 +1,43 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.personbruker.dittnav.eventaggregator.common.database.util.getUtcDateTime
+import no.nav.personbruker.dittnav.eventaggregator.common.database.util.list
+import java.sql.Connection
+import java.sql.ResultSet
+
+fun Connection.deleteAllDoknotifikasjonStatusBeskjed() {
+    prepareStatement("""DELETE FROM doknotifikasjon_status_beskjed""")
+        .use {it.execute()}
+}
+
+fun Connection.deleteAllDoknotifikasjonStatusOppgave() {
+    prepareStatement("""DELETE FROM doknotifikasjon_status_oppgave""")
+        .use {it.execute()}
+}
+
+fun Connection.getAllDoknotifikasjonBeskjed(): List<DoknotStatusDTO> {
+    return prepareStatement("""SELECT * FROM doknotifikasjon_status_beskjed""")
+        .use {
+            it.executeQuery().list {
+                toDoknotStatusDTO()
+            }
+        }
+}
+
+fun Connection.getAllDoknotifikasjonOppgave(): List<DoknotStatusDTO> {
+    return prepareStatement("""SELECT * FROM doknotifikasjon_status_oppgave""")
+        .use {
+            it.executeQuery().list {
+                toDoknotStatusDTO()
+            }
+        }
+}
+
+private fun ResultSet.toDoknotStatusDTO() = DoknotStatusDTO(
+    eventId = getString("eventId"),
+    status = getString("status"),
+    melding = getString("melding"),
+    distribusjonsId = getLong("distribusjonsId"),
+    antallOppdateringer = getInt("antall_oppdateringer"),
+    tidspunkt = getUtcDateTime("tidspunkt"),
+)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneEventServiceTest.kt
@@ -128,7 +128,7 @@ class DoneEventServiceTest {
     fun `Skal ikke lagre Done-event i cache paa nytt hvis Done-event med samme id allerede er mottatt`() {
         val record1 = ConsumerRecord(KafkaTestTopics.beskjedInternTopicName, 1, 1, AvroNokkelInternObjectMother.createNokkelWithEventId(eventId = 5), AvroDoneObjectMother.createDone())
         val record2 = ConsumerRecord(KafkaTestTopics.beskjedInternTopicName, 1, 1, AvroNokkelInternObjectMother.createNokkelWithEventId(eventId = 5), AvroDoneObjectMother.createDone())
-        val records = ConsumerRecordsObjectMother.wrapInConsumerRecords(listOf(record1, record2))
+        val records = ConsumerRecordsObjectMother.wrapInConsumerRecords(listOf(record1, record2), "doneTopic")
         runBlocking {
             doneEventService.processEvents(records)
             val allDone = database.dbQuery { getAllDoneEvent() }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneIT.kt
@@ -13,6 +13,7 @@ import no.nav.personbruker.dittnav.eventaggregator.beskjed.getAllBeskjedByAktiv
 import no.nav.personbruker.dittnav.eventaggregator.common.database.BrukernotifikasjonPersistingService
 import no.nav.personbruker.dittnav.eventaggregator.common.database.LocalPostgresDatabase
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.Consumer
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createBeskjedRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createEventRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.delayUntilCommittedOffset
 import no.nav.personbruker.dittnav.eventaggregator.done.schema.AvroDoneObjectMother
@@ -53,7 +54,7 @@ class DoneIT {
 
     @Test
     fun `Skal lese done-eventer og sette relaterte eventer til inaktive`() {
-        val beskjeder = createEventRecords(10, beskjedTopicPartition, AvroBeskjedObjectMother::createBeskjed)
+        val beskjeder = createBeskjedRecords(10, beskjedTopicPartition)
         beskjeder.forEach { beskjedConsumerMock.addRecord(it) }
 
         runBlocking {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneRepositoryTest.kt
@@ -72,7 +72,7 @@ class DoneRepositoryTest {
             doneRepository.createInOneBatch(alreadyPersisted)
             val result = doneRepository.createInOneBatch(toCreate)
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 
@@ -85,7 +85,7 @@ class DoneRepositoryTest {
             doneRepository.createInOneBatch(alreadyPersisted)
             val result = doneRepository.createOneByOneToFilterOutTheProblematicEvents(toCreate)
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksIT.kt
@@ -9,6 +9,7 @@ import no.nav.personbruker.dittnav.eventaggregator.common.database.Brukernotifik
 import no.nav.personbruker.dittnav.eventaggregator.common.database.LocalPostgresDatabase
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.Consumer
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createEventRecords
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createInnboksRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.delayUntilCommittedOffset
 import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsProbe
 import org.apache.kafka.clients.consumer.MockConsumer
@@ -35,7 +36,7 @@ class InnboksIT {
 
     @Test
     fun `Skal lese inn Innboks-eventer og skrive de til databasen`() {
-        val innboksEventer = createEventRecords(10, innboksTopicPartition, AvroInnboksObjectMother::createInnboks)
+        val innboksEventer = createInnboksRecords(10, innboksTopicPartition)
         innboksEventer.forEach { innboksConsumerMock.addRecord(it) }
 
         runBlocking {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksRepositoryTest.kt
@@ -59,7 +59,7 @@ class InnboksRepositoryTest {
             val result = innboksRepository.createInOneBatch(toCreate)
 
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 
@@ -75,7 +75,7 @@ class InnboksRepositoryTest {
             val result = innboksRepository.createOneByOneToFilterOutTheProblematicEvents(toCreate)
 
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveIT.kt
@@ -9,6 +9,7 @@ import no.nav.personbruker.dittnav.eventaggregator.common.database.Brukernotifik
 import no.nav.personbruker.dittnav.eventaggregator.common.database.LocalPostgresDatabase
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.Consumer
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createEventRecords
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createOppgaveRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.delayUntilCommittedOffset
 import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsProbe
 import org.apache.kafka.clients.consumer.MockConsumer
@@ -35,7 +36,7 @@ class OppgaveIT {
 
     @Test
     fun `Skal lese inn Oppgave-eventer og skrive de til databasen`() {
-        val oppgaver = createEventRecords(10, oppgaveTopicPartition, AvroOppgaveObjectMother::createOppgave)
+        val oppgaver = createOppgaveRecords(10, oppgaveTopicPartition)
         oppgaver.forEach { oppgaveConsumerMock.addRecord(it) }
 
         runBlocking {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveObjectMother.kt
@@ -56,6 +56,13 @@ object OppgaveObjectMother {
         return giveMeOppgave(eventId = eventId, fodselsnummer = fodselsnummer, forstBehandlet = forstBehandlet)
     }
 
+    fun giveMeOppgaveWithEventIdAndAppnavn(eventId: String, appnavn: String): Oppgave {
+        return giveMeOppgave(
+            eventId = eventId,
+            appnavn = appnavn
+        )
+    }
+
     private fun giveMeOppgave(
         systembruker: String = defaultSystembruker,
         namespace: String = defaultNamespace,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveRepositoryTest.kt
@@ -59,7 +59,7 @@ class OppgaveRepositoryTest {
             val result = oppgaveRepository.createInOneBatch(toCreate)
 
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 
@@ -75,7 +75,7 @@ class OppgaveRepositoryTest {
             val result = oppgaveRepository.createOneByOneToFilterOutTheProblematicEvents(toCreate)
 
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringIT.kt
@@ -9,6 +9,7 @@ import no.nav.personbruker.dittnav.eventaggregator.common.database.Brukernotifik
 import no.nav.personbruker.dittnav.eventaggregator.common.database.LocalPostgresDatabase
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.Consumer
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createEventRecords
+import no.nav.personbruker.dittnav.eventaggregator.common.kafka.createStatusoppdateringRecords
 import no.nav.personbruker.dittnav.eventaggregator.common.kafka.delayUntilCommittedOffset
 import no.nav.personbruker.dittnav.eventaggregator.metrics.EventMetricsProbe
 import org.apache.kafka.clients.consumer.MockConsumer
@@ -47,11 +48,11 @@ class StatusoppdateringIT {
 
     @Test
     fun `Skal lese inn Statusoppdatering-eventer og skrive de til databasen`() {
-        val statusoppdateringer = createEventRecords(
+        val statusoppdateringer = createStatusoppdateringRecords(
             10,
-            statusoppdateringTopicPartition,
-            AvroStatusoppdateringObjectMother::createStatusoppdatering
+            statusoppdateringTopicPartition
         )
+
         statusoppdateringer.forEach { statusoppdateringConsumerMock.addRecord(it) }
 
         runBlocking {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/statusoppdatering/StatusoppdateringRepositoryTest.kt
@@ -59,7 +59,7 @@ class StatusoppdateringRepositoryTest {
             val result = statusoppdateringRepository.createInOneBatch(toCreate)
 
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 
@@ -75,7 +75,7 @@ class StatusoppdateringRepositoryTest {
             val result = statusoppdateringRepository.createOneByOneToFilterOutTheProblematicEvents(toCreate)
 
             result.getPersistedEntitites() shouldBe expected
-            result.getConflictingEntities() shouldBe alreadyPersisted
+            result.getUnalteredEntities() shouldBe alreadyPersisted
         }
     }
 }


### PR DESCRIPTION
Legger til lesing av doknotifikasjon-status. Statuser legges i egne tabeller for beskjed og oppgave. Vi beholder kun nyeste status per brukernotifikasjon, og teller antall ganger status har vært endret. Vi ignorerer gjentatte, like statuser.

Vi forkaster statuser der bestillerId og bestillingsId ikke har en beskjed eller oppgave med matchende appnavn og eventId. Vi forkaster også eventer som har match, men der matchende beskjed/oppgave ikke er satt til ekstern varsling.

Det er satt opp nye paneler i boardet til varselbestiller. Esempel i dev [finnes her](https://grafana.nais.io/d/kPFPQYfnk/dittnav-varselbestiller-gcp?orgId=1&var-influx=team-min-side-influxdb-dev&var-namespace=All&var-event_type=All&var-producer=All). 