### PR TITLE
Legg til parsing og lagring av kanal der esktern varsel ble sendt.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusDto.kt
@@ -1,0 +1,11 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+data class DoknotifikasjonStatusDto(
+    val eventId: String,
+    val bestillerAppnavn: String,
+    val status: String,
+    val melding: String,
+    val distribusjonsId: Long,
+    val kanaler: List<String>,
+    val antallOppdateringer: Int = 1
+)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusRepository.kt
@@ -5,19 +5,38 @@ import no.nav.personbruker.dittnav.eventaggregator.common.database.Database
 import no.nav.personbruker.dittnav.eventaggregator.common.database.ListPersistActionResult
 
 class DoknotifikasjonStatusRepository(private val database: Database) {
-    suspend fun updateStatusesForBeskjed(dokStatuses: List<DoknotifikasjonStatus>): ListPersistActionResult<DoknotifikasjonStatus> {
+
+    suspend fun getStatusesForBeskjed(eventIds: List<String>): List<DoknotifikasjonStatusDto> {
+        return database.queryWithExceptionTranslation {
+            getDoknotifikasjonStatusesForBeskjed(eventIds)
+        }
+    }
+
+    suspend fun getStatusesForOppgave(eventIds: List<String>): List<DoknotifikasjonStatusDto> {
+        return database.queryWithExceptionTranslation {
+            getDoknotifikasjonStatusesForOppgave(eventIds)
+        }
+    }
+
+    suspend fun getStatusesForInnboks(eventIds: List<String>): List<DoknotifikasjonStatusDto> {
+        return database.queryWithExceptionTranslation {
+            getDoknotifikasjonStatusesForInnboks(eventIds)
+        }
+    }
+
+    suspend fun updateStatusesForBeskjed(dokStatuses: List<DoknotifikasjonStatusDto>): ListPersistActionResult<DoknotifikasjonStatusDto> {
         return database.queryWithExceptionTranslation {
             upsertDoknotifikasjonStatusForBeskjed(dokStatuses)
         }
     }
 
-    suspend fun updateStatusesForOppgave(dokStatuses: List<DoknotifikasjonStatus>): ListPersistActionResult<DoknotifikasjonStatus>  {
+    suspend fun updateStatusesForOppgave(dokStatuses: List<DoknotifikasjonStatusDto>): ListPersistActionResult<DoknotifikasjonStatusDto>  {
         return database.queryWithExceptionTranslation {
             upsertDoknotifikasjonStatusForOppgave(dokStatuses)
         }
     }
 
-    suspend fun updateStatusesForInnboks(dokStatuses: List<DoknotifikasjonStatus>): ListPersistActionResult<DoknotifikasjonStatus>  {
+    suspend fun updateStatusesForInnboks(dokStatuses: List<DoknotifikasjonStatusDto>): ListPersistActionResult<DoknotifikasjonStatusDto>  {
         return database.queryWithExceptionTranslation {
             upsertDoknotifikasjonStatusForInnboks(dokStatuses)
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusService.kt
@@ -14,7 +14,9 @@ class DoknotifikasjonStatusService(
     override suspend fun processEvents(events: ConsumerRecords<String, DoknotifikasjonStatus>) {
         metricsProbe.runWithMetrics {
 
-            val allStatuses = events.map { it.value() }
+            val allStatuses = events
+                .map { it.value() }
+                .map { DoknotofikasjonStatusTransformer.toInternal(it) }
 
             countStatuses(allStatuses)
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotofikasjonStatusTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotofikasjonStatusTransformer.kt
@@ -1,0 +1,34 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
+
+object DoknotofikasjonStatusTransformer {
+    fun toInternal(external: DoknotifikasjonStatus): DoknotifikasjonStatusDto {
+        return DoknotifikasjonStatusDto(
+            eventId = external.getBestillingsId(),
+            bestillerAppnavn = external.getBestillerId(),
+            status = external.getStatus(),
+            melding = external.getMelding(),
+            distribusjonsId = external.getDistribusjonId(),
+            kanaler = getKanaler(external)
+        )
+    }
+
+    private fun getKanaler(external: DoknotifikasjonStatus): List<String> {
+        val kanal = parseKanal(external.getMelding())
+
+        return if (kanal != null) {
+            listOf(kanal)
+        } else {
+            emptyList()
+        }
+    }
+
+    private val kanalMeldingPattern = "notifikasjon sendt via (\\w+)".toRegex()
+
+    private fun parseKanal(melding: String): String? {
+        return kanalMeldingPattern.find(melding)?.destructured?.let { (kanal) ->
+            kanal.uppercase()
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/UpdateStatusResult.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/UpdateStatusResult.kt
@@ -1,9 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
 
-import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
-
 data class UpdateStatusResult(
-    val updatedStatuses: List<DoknotifikasjonStatus>,
-    val unchangedStatuses: List<DoknotifikasjonStatus>,
-    val unmatchedStatuses: List<DoknotifikasjonStatus>
+    val updatedStatuses: List<DoknotifikasjonStatusDto>,
+    val unmatchedStatuses: List<DoknotifikasjonStatusDto>
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/metrics/DoknotifikasjonStatusMetricsProbe.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/metrics/DoknotifikasjonStatusMetricsProbe.kt
@@ -12,7 +12,6 @@ class DoknotifikasjonStatusMetricsProbe(private val metricsReporter: MetricsRepo
         if (session.getTotalEventsProcessed() > 0) {
             handleStatusesProcessed(session)
             handleStatusesUpdated(session)
-            handleStatusesUnchanged(session)
             handleStatusesUnmatched(session)
             handleBatchInfo(session, processingTime)
         }
@@ -27,10 +26,6 @@ class DoknotifikasjonStatusMetricsProbe(private val metricsReporter: MetricsRepo
 
     private suspend fun handleStatusesUpdated(session: DoknotifikasjonStatusMetricsSession) {
         reportForEachCount(KAFKA_DOKNOT_STATUS_UPDATED, session.getCountOfStatuesSuccessfullyUpdated())
-    }
-
-    private suspend fun handleStatusesUnchanged(session: DoknotifikasjonStatusMetricsSession) {
-        reportForEachCount(KAFKA_DOKNOT_STATUS_UNCHANGED, session.getCountOfStatuesWithNoChange())
     }
 
     private suspend fun handleStatusesUnmatched(session: DoknotifikasjonStatusMetricsSession) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricNames.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/metrics/metricNames.kt
@@ -19,6 +19,5 @@ const val KAFKA_DUPLICATE_EVENTS_ON_TOPIC = "$METRIC_NAMESPACE.topic.duplicates"
 
 const val KAFKA_DOKNOT_STATUS_TOTAL_PROCESSED = "$METRIC_NAMESPACE.doknot.status.total.processed"
 const val KAFKA_DOKNOT_STATUS_UPDATED = "$METRIC_NAMESPACE.doknot.status.updated"
-const val KAFKA_DOKNOT_STATUS_UNCHANGED = "$METRIC_NAMESPACE.doknot.status.unchanged"
 const val KAFKA_DOKNOT_STATUS_IGNORED = "$METRIC_NAMESPACE.doknot.status.ignored"
 const val KAFKA_DOKNOT_STATUS_BATCH = "$METRIC_NAMESPACE.doknot.status.batch"

--- a/src/main/resources/db/migration/V1.1.26__Doknotiikasjon_status_kanaler.sql
+++ b/src/main/resources/db/migration/V1.1.26__Doknotiikasjon_status_kanaler.sql
@@ -1,0 +1,3 @@
+ALTER TABLE doknotifikasjon_status_beskjed ADD COLUMN kanaler text;
+ALTER TABLE doknotifikasjon_status_oppgave ADD COLUMN kanaler text;
+ALTER TABLE doknotifikasjon_status_innboks ADD COLUMN kanaler text;

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusDtoObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusDtoObjectMother.kt
@@ -1,0 +1,34 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.doknotifikasjon.schemas.DoknotifikasjonStatus
+
+object DoknotifikasjonStatusDtoObjectMother {
+
+    private val defaultBestillerAppnavn = "dummyBestiller"
+    private val defaultStatus = "INFO"
+    private val defaultMelding = "dummyMelding"
+    private val defaultDistribusjonsId = 1L
+    private val defaultKanaler = emptyList<String>()
+    private val defaultAntallOppdateringer = 1
+
+    fun createDoknotifikasjonStatusDto(
+        eventId: String,
+        bestillerAppnavn: String = defaultBestillerAppnavn,
+        status: String = defaultStatus,
+        melding: String = defaultMelding,
+        distribusjonsId: Long = defaultDistribusjonsId,
+        kanaler: List<String> = defaultKanaler,
+        antallOppdateringer: Int = defaultAntallOppdateringer
+    ): DoknotifikasjonStatusDto {
+        return DoknotifikasjonStatusDto(
+            eventId = eventId,
+            bestillerAppnavn = bestillerAppnavn,
+            status = status,
+            melding = melding,
+            distribusjonsId = distribusjonsId,
+            kanaler = kanaler,
+            antallOppdateringer = antallOppdateringer,
+        )
+    }
+}
+

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusQueryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusQueryTest.kt
@@ -51,7 +51,7 @@ internal class DoknotifikasjonStatusQueryTest {
 
     @Test
     fun `should create insert new status for beskjed when none exists for eventId`() = runBlocking {
-        val statusUpdate = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdBeskjed)
+        val statusUpdate = DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto(bestillingsIdBeskjed)
 
         val persistResult = database.dbQuery {
             upsertDoknotifikasjonStatusForBeskjed(listOf(statusUpdate))
@@ -63,10 +63,10 @@ internal class DoknotifikasjonStatusQueryTest {
 
         allStatuses.size shouldBe 1
 
-        allStatuses[0].eventId shouldBe statusUpdate.getBestillingsId()
-        allStatuses[0].status shouldBe statusUpdate.getStatus()
-        allStatuses[0].melding shouldBe statusUpdate.getMelding()
-        allStatuses[0].distribusjonsId shouldBe statusUpdate.getDistribusjonId()
+        allStatuses[0].eventId shouldBe statusUpdate.eventId
+        allStatuses[0].status shouldBe statusUpdate.status
+        allStatuses[0].melding shouldBe statusUpdate.melding
+        allStatuses[0].distribusjonsId shouldBe statusUpdate.distribusjonsId
         allStatuses[0].antallOppdateringer shouldBe 1
 
         persistResult.allEntitiesPersisted() shouldBe true
@@ -75,13 +75,14 @@ internal class DoknotifikasjonStatusQueryTest {
 
     @Test
     fun `should update status for beskjed when one already exists for eventId`() = runBlocking {
-        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdBeskjed)
+        val statusUpdate1 = DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto(bestillingsIdBeskjed)
 
-        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(
-            bestillingsId = bestillingsIdBeskjed,
+        val statusUpdate2 = DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto(
+            eventId = bestillingsIdBeskjed,
             status = "new status",
             melding = "new melding",
-            distribusjonsId = 321
+            distribusjonsId = 321,
+            antallOppdateringer = 2
         )
 
         val persistResult = database.dbQuery {
@@ -94,10 +95,10 @@ internal class DoknotifikasjonStatusQueryTest {
 
         allStatuses.size shouldBe 1
 
-        allStatuses[0].eventId shouldBe statusUpdate2.getBestillingsId()
-        allStatuses[0].status shouldBe statusUpdate2.getStatus()
-        allStatuses[0].melding shouldBe statusUpdate2.getMelding()
-        allStatuses[0].distribusjonsId shouldBe statusUpdate2.getDistribusjonId()
+        allStatuses[0].eventId shouldBe statusUpdate2.eventId
+        allStatuses[0].status shouldBe statusUpdate2.status
+        allStatuses[0].melding shouldBe statusUpdate2.melding
+        allStatuses[0].distribusjonsId shouldBe statusUpdate2.distribusjonsId
         allStatuses[0].antallOppdateringer shouldBe 2
 
 
@@ -107,30 +108,8 @@ internal class DoknotifikasjonStatusQueryTest {
     }
 
     @Test
-    fun `should not make any changes for identical status updates for beskjed`() = runBlocking {
-        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdBeskjed)
-        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdBeskjed)
-
-        val persistResult = database.dbQuery {
-            upsertDoknotifikasjonStatusForBeskjed(listOf(statusUpdate1, statusUpdate2))
-        }
-
-        val allStatuses = database.dbQuery {
-            getAllDoknotifikasjonBeskjed()
-        }
-
-        allStatuses.size shouldBe 1
-
-        allStatuses[0].antallOppdateringer shouldBe 1
-
-        persistResult.allEntitiesPersisted() shouldBe false
-        persistResult.getPersistedEntitites() shouldContain statusUpdate1
-        persistResult.getUnalteredEntities() shouldContain statusUpdate2
-    }
-
-    @Test
     fun `should create insert new status for oppgave when none exists for eventId`() = runBlocking {
-        val statusUpdate = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdOppgave)
+        val statusUpdate = DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto(bestillingsIdOppgave)
 
         val persistResult = database.dbQuery {
             upsertDoknotifikasjonStatusForOppgave(listOf(statusUpdate))
@@ -142,10 +121,10 @@ internal class DoknotifikasjonStatusQueryTest {
 
         allStatuses.size shouldBe 1
 
-        allStatuses[0].eventId shouldBe statusUpdate.getBestillingsId()
-        allStatuses[0].status shouldBe statusUpdate.getStatus()
-        allStatuses[0].melding shouldBe statusUpdate.getMelding()
-        allStatuses[0].distribusjonsId shouldBe statusUpdate.getDistribusjonId()
+        allStatuses[0].eventId shouldBe statusUpdate.eventId
+        allStatuses[0].status shouldBe statusUpdate.status
+        allStatuses[0].melding shouldBe statusUpdate.melding
+        allStatuses[0].distribusjonsId shouldBe statusUpdate.distribusjonsId
         allStatuses[0].antallOppdateringer shouldBe 1
 
         persistResult.allEntitiesPersisted() shouldBe true
@@ -154,13 +133,14 @@ internal class DoknotifikasjonStatusQueryTest {
 
     @Test
     fun `should update status for oppgave when one already exists for eventId`() = runBlocking {
-        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdOppgave)
+        val statusUpdate1 = DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto(bestillingsIdOppgave)
 
-        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(
-            bestillingsId = bestillingsIdOppgave,
+        val statusUpdate2 = DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto(
+            eventId = bestillingsIdOppgave,
             status = "new status",
             melding = "new melding",
-            distribusjonsId = 321
+            distribusjonsId = 321,
+            antallOppdateringer = 2
         )
 
         val persistResult = database.dbQuery {
@@ -173,10 +153,10 @@ internal class DoknotifikasjonStatusQueryTest {
 
         allStatuses.size shouldBe 1
 
-        allStatuses[0].eventId shouldBe statusUpdate2.getBestillingsId()
-        allStatuses[0].status shouldBe statusUpdate2.getStatus()
-        allStatuses[0].melding shouldBe statusUpdate2.getMelding()
-        allStatuses[0].distribusjonsId shouldBe statusUpdate2.getDistribusjonId()
+        allStatuses[0].eventId shouldBe statusUpdate2.eventId
+        allStatuses[0].status shouldBe statusUpdate2.status
+        allStatuses[0].melding shouldBe statusUpdate2.melding
+        allStatuses[0].distribusjonsId shouldBe statusUpdate2.distribusjonsId
         allStatuses[0].antallOppdateringer shouldBe 2
 
         persistResult.allEntitiesPersisted() shouldBe true
@@ -185,30 +165,8 @@ internal class DoknotifikasjonStatusQueryTest {
     }
 
     @Test
-    fun `should not make any changes for identical status updates for oppgave`() = runBlocking {
-        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdOppgave)
-        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdOppgave)
-
-        val persistResult = database.dbQuery {
-            upsertDoknotifikasjonStatusForOppgave(listOf(statusUpdate1, statusUpdate2))
-        }
-
-        val allStatuses = database.dbQuery {
-            getAllDoknotifikasjonOppgave()
-        }
-
-        allStatuses.size shouldBe 1
-
-        allStatuses[0].antallOppdateringer shouldBe 1
-
-        persistResult.allEntitiesPersisted() shouldBe false
-        persistResult.getPersistedEntitites() shouldContain statusUpdate1
-        persistResult.getUnalteredEntities() shouldContain statusUpdate2
-    }
-
-    @Test
     fun `should create insert new status for innboks when none exists for eventId`() = runBlocking {
-        val statusUpdate = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdInnboks)
+        val statusUpdate = DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto(bestillingsIdInnboks)
 
         val persistResult = database.dbQuery {
             upsertDoknotifikasjonStatusForInnboks(listOf(statusUpdate))
@@ -220,10 +178,10 @@ internal class DoknotifikasjonStatusQueryTest {
 
         allStatuses.size shouldBe 1
 
-        allStatuses[0].eventId shouldBe statusUpdate.getBestillingsId()
-        allStatuses[0].status shouldBe statusUpdate.getStatus()
-        allStatuses[0].melding shouldBe statusUpdate.getMelding()
-        allStatuses[0].distribusjonsId shouldBe statusUpdate.getDistribusjonId()
+        allStatuses[0].eventId shouldBe statusUpdate.eventId
+        allStatuses[0].status shouldBe statusUpdate.status
+        allStatuses[0].melding shouldBe statusUpdate.melding
+        allStatuses[0].distribusjonsId shouldBe statusUpdate.distribusjonsId
         allStatuses[0].antallOppdateringer shouldBe 1
 
         persistResult.allEntitiesPersisted() shouldBe true
@@ -232,13 +190,14 @@ internal class DoknotifikasjonStatusQueryTest {
 
     @Test
     fun `should update status for innboks when one already exists for eventId`() = runBlocking {
-        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdInnboks)
+        val statusUpdate1 = DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto(bestillingsIdInnboks)
 
-        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(
-            bestillingsId = bestillingsIdInnboks,
+        val statusUpdate2 = DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto(
+            eventId = bestillingsIdInnboks,
             status = "new status",
             melding = "new melding",
-            distribusjonsId = 321
+            distribusjonsId = 321,
+            antallOppdateringer = 2
         )
 
         val persistResult = database.dbQuery {
@@ -251,37 +210,15 @@ internal class DoknotifikasjonStatusQueryTest {
 
         allStatuses.size shouldBe 1
 
-        allStatuses[0].eventId shouldBe statusUpdate2.getBestillingsId()
-        allStatuses[0].status shouldBe statusUpdate2.getStatus()
-        allStatuses[0].melding shouldBe statusUpdate2.getMelding()
-        allStatuses[0].distribusjonsId shouldBe statusUpdate2.getDistribusjonId()
+        allStatuses[0].eventId shouldBe statusUpdate2.eventId
+        allStatuses[0].status shouldBe statusUpdate2.status
+        allStatuses[0].melding shouldBe statusUpdate2.melding
+        allStatuses[0].distribusjonsId shouldBe statusUpdate2.distribusjonsId
         allStatuses[0].antallOppdateringer shouldBe 2
 
         persistResult.allEntitiesPersisted() shouldBe true
         persistResult.getPersistedEntitites() shouldContain statusUpdate1
         persistResult.getPersistedEntitites() shouldContain statusUpdate2
-    }
-
-    @Test
-    fun `should not make any changes for identical status updates for innboks`() = runBlocking {
-        val statusUpdate1 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdInnboks)
-        val statusUpdate2 = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(bestillingsIdInnboks)
-
-        val persistResult = database.dbQuery {
-            upsertDoknotifikasjonStatusForInnboks(listOf(statusUpdate1, statusUpdate2))
-        }
-
-        val allStatuses = database.dbQuery {
-            getAllDoknotifikasjonInnboks()
-        }
-
-        allStatuses.size shouldBe 1
-
-        allStatuses[0].antallOppdateringer shouldBe 1
-
-        persistResult.allEntitiesPersisted() shouldBe false
-        persistResult.getPersistedEntitites() shouldContain statusUpdate1
-        persistResult.getUnalteredEntities() shouldContain statusUpdate2
     }
 
     private fun createBeskjedInDb(): Beskjed {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusServiceTest.kt
@@ -53,22 +53,22 @@ internal class DoknotifikasjonStatusServiceTest {
         val updateResultInnboks: UpdateStatusResult = mockk()
 
         coEvery {
-            statusUpdater.updateStatusForBeskjed(allStatuses)
+            statusUpdater.updateStatusForBeskjed(any())
         } returns updateResultBeskjed
 
         coEvery {
-            statusUpdater.updateStatusForOppgave(allStatuses)
+            statusUpdater.updateStatusForOppgave(any())
         } returns updateResultOppgave
 
         coEvery {
-            statusUpdater.updateStatusForInnboks(allStatuses)
+            statusUpdater.updateStatusForInnboks(any())
         } returns updateResultInnboks
 
         runBlocking {
             doknotifikasjonStatusService.processEvents(statusEvents)
         }
 
-        verify(exactly = 1) { metricsSession.countStatuses(allStatuses) }
+        verify(exactly = 1) { metricsSession.countStatuses(any()) }
         verify(exactly = 1) { metricsSession.recordUpdateResult(EventType.BESKJED_INTERN, updateResultBeskjed) }
         verify(exactly = 1) { metricsSession.recordUpdateResult(EventType.OPPGAVE_INTERN, updateResultOppgave) }
         verify(exactly = 1) { metricsSession.recordUpdateResult(EventType.INNBOKS_INTERN, updateResultInnboks) }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusUpdaterTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusUpdaterTest.kt
@@ -3,15 +3,12 @@ package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import io.mockk.clearMocks
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedObjectMother.giveMeBeskjedWithEventIdAndAppnavn
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.BeskjedRepository
 import no.nav.personbruker.dittnav.eventaggregator.common.createPersistActionResult
-import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.DoknotifikasjonStatusDtoObjectMother.createDoknotifikasjonStatusDto
 import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksObjectMother.giveMeInnboksWithEventIdAndAppnavn
 import no.nav.personbruker.dittnav.eventaggregator.innboks.InnboksRepository
 import no.nav.personbruker.dittnav.eventaggregator.oppgave.OppgaveObjectMother.giveMeOppgaveWithEventIdAndAppnavn
@@ -28,9 +25,9 @@ internal class DoknotifikasjonStatusUpdaterTest {
 
     private val statusUpdater = DoknotifikasjonStatusUpdater(beskjedRepository, oppgaveRepository, innboksRepository, doknotStatusRepository)
 
-    private val status1 = createDoknotifikasjonStatus("status-1")
-    private val status2 = createDoknotifikasjonStatus("status-2")
-    private val status3 = createDoknotifikasjonStatus("status-3")
+    private val status1 = createDoknotifikasjonStatusDto("status-1")
+    private val status2 = createDoknotifikasjonStatusDto("status-2")
+    private val status3 = createDoknotifikasjonStatusDto("status-3")
 
     private val statuses = listOf(status1, status2, status3)
 
@@ -41,8 +38,8 @@ internal class DoknotifikasjonStatusUpdaterTest {
 
     @Test
     fun `should attempt to match statuses with existing beskjed events and update`() {
-        val beskjed1 = giveMeBeskjedWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
-        val beskjed2 = giveMeBeskjedWithEventIdAndAppnavn(status2.getBestillingsId(), status2.getBestillerId())
+        val beskjed1 = giveMeBeskjedWithEventIdAndAppnavn(status1.eventId, status1.bestillerAppnavn)
+        val beskjed2 = giveMeBeskjedWithEventIdAndAppnavn(status2.eventId, status2.bestillerAppnavn)
 
         coEvery {
             beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any())
@@ -57,12 +54,15 @@ internal class DoknotifikasjonStatusUpdaterTest {
             doknotStatusRepository.updateStatusesForBeskjed(listOf(status1, status2))
         } returns persistResult
 
+        coEvery {
+            doknotStatusRepository.getStatusesForBeskjed(any())
+        } returns emptyList()
+
         val result = runBlocking {
             statusUpdater.updateStatusForBeskjed(statuses)
         }
 
         result.updatedStatuses shouldContain status1
-        result.unchangedStatuses shouldContain status2
         result.unmatchedStatuses shouldContain status3
 
         coVerify(exactly = 1) { beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any()) }
@@ -72,8 +72,8 @@ internal class DoknotifikasjonStatusUpdaterTest {
 
     @Test
     fun `should not consider status to match beskjed if appnavn differs from bestillingsId`() {
-        val beskjed1 = giveMeBeskjedWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
-        val beskjed2 = giveMeBeskjedWithEventIdAndAppnavn(status2.getBestillingsId(), "other")
+        val beskjed1 = giveMeBeskjedWithEventIdAndAppnavn(status1.eventId, status1.bestillerAppnavn)
+        val beskjed2 = giveMeBeskjedWithEventIdAndAppnavn(status2.eventId, "other")
 
         coEvery {
             beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any())
@@ -88,12 +88,15 @@ internal class DoknotifikasjonStatusUpdaterTest {
             doknotStatusRepository.updateStatusesForBeskjed(listOf(status1))
         } returns persistResult
 
+        coEvery {
+            doknotStatusRepository.getStatusesForBeskjed(any())
+        } returns emptyList()
+
         val result = runBlocking {
             statusUpdater.updateStatusForBeskjed(statuses)
         }
 
         result.updatedStatuses shouldContain status1
-        result.unchangedStatuses.isEmpty() shouldBe true
         result.unmatchedStatuses shouldContainAll listOf(status2, status3)
 
         coVerify(exactly = 1) { beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any()) }
@@ -101,11 +104,62 @@ internal class DoknotifikasjonStatusUpdaterTest {
         coVerify(exactly = 0) { oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any()) }
     }
 
+    @Test
+    fun `should update if status already exists for beskjed`() {
+
+        val newStatus1 = createDoknotifikasjonStatusDto("beskjed",kanaler = listOf("SMS"))
+
+        val newStatus2 = createDoknotifikasjonStatusDto(
+            newStatus1.eventId,
+            kanaler = listOf("SMS"),
+            status = "newestStatus",
+            melding = "newestMelding"
+        )
+
+        val beskjed = giveMeBeskjedWithEventIdAndAppnavn(newStatus1.eventId, newStatus1.bestillerAppnavn)
+
+        val existingStatus = createDoknotifikasjonStatusDto(
+            eventId = newStatus1.eventId,
+            antallOppdateringer = 3,
+            kanaler = listOf("EPOST")
+        )
+
+        coEvery {
+            beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any())
+        } returns listOf(beskjed)
+
+        val persistResult = createPersistActionResult(
+            successful = listOf(newStatus2),
+            unchanged = emptyList()
+        )
+
+        val persistedSlot = slot<List<DoknotifikasjonStatusDto>>()
+
+        coEvery {
+            doknotStatusRepository.getStatusesForBeskjed(listOf(newStatus1.eventId))
+        } returns listOf(existingStatus)
+
+        coEvery {
+            doknotStatusRepository.updateStatusesForBeskjed(capture(persistedSlot))
+        } returns persistResult
+
+        runBlocking {
+            statusUpdater.updateStatusForBeskjed(listOf(newStatus1, newStatus2))
+        }
+
+        val persistedStatus = persistedSlot.captured[0]
+
+        persistedStatus.status shouldBe newStatus2.status
+        persistedStatus.melding shouldBe newStatus2.melding
+        persistedStatus.kanaler.size shouldBe 2
+        persistedStatus.kanaler shouldContainAll listOf("SMS", "EPOST")
+        persistedStatus.antallOppdateringer shouldBe 5
+    }
 
     @Test
     fun `should attempt to match statuses with existing oppgave events and update`() {
-        val oppgave1 = giveMeOppgaveWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
-        val oppgave2 = giveMeOppgaveWithEventIdAndAppnavn(status2.getBestillingsId(), status2.getBestillerId())
+        val oppgave1 = giveMeOppgaveWithEventIdAndAppnavn(status1.eventId, status1.bestillerAppnavn)
+        val oppgave2 = giveMeOppgaveWithEventIdAndAppnavn(status2.eventId, status2.bestillerAppnavn)
 
         coEvery {
             oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any())
@@ -120,12 +174,15 @@ internal class DoknotifikasjonStatusUpdaterTest {
             doknotStatusRepository.updateStatusesForOppgave(listOf(status1, status2))
         } returns persistResult
 
+        coEvery {
+            doknotStatusRepository.getStatusesForOppgave(any())
+        } returns emptyList()
+
         val result = runBlocking {
             statusUpdater.updateStatusForOppgave(statuses)
         }
 
         result.updatedStatuses shouldContain status1
-        result.unchangedStatuses shouldContain status2
         result.unmatchedStatuses shouldContain status3
 
         coVerify(exactly = 1) { oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any()) }
@@ -135,8 +192,8 @@ internal class DoknotifikasjonStatusUpdaterTest {
 
     @Test
     fun `should not consider status to match oppgave if appnavn differs from bestillingsId`() {
-        val oppgave1 = giveMeOppgaveWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
-        val oppgave2 = giveMeOppgaveWithEventIdAndAppnavn(status2.getBestillingsId(), "other")
+        val oppgave1 = giveMeOppgaveWithEventIdAndAppnavn(status1.eventId, status1.bestillerAppnavn)
+        val oppgave2 = giveMeOppgaveWithEventIdAndAppnavn(status2.eventId, "other")
 
         coEvery {
             oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any())
@@ -151,12 +208,15 @@ internal class DoknotifikasjonStatusUpdaterTest {
             doknotStatusRepository.updateStatusesForOppgave(listOf(status1))
         } returns persistResult
 
+        coEvery {
+            doknotStatusRepository.getStatusesForOppgave(any())
+        } returns emptyList()
+
         val result = runBlocking {
             statusUpdater.updateStatusForOppgave(statuses)
         }
 
         result.updatedStatuses shouldContain status1
-        result.unchangedStatuses.isEmpty() shouldBe true
         result.unmatchedStatuses shouldContainAll listOf(status2, status3)
 
         coVerify(exactly = 1) { oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any()) }
@@ -165,9 +225,61 @@ internal class DoknotifikasjonStatusUpdaterTest {
     }
 
     @Test
+    fun `should update if status already exists for oppgave`() {
+
+        val newStatus1 = createDoknotifikasjonStatusDto("oppgave",kanaler = listOf("SMS"))
+
+        val newStatus2 = createDoknotifikasjonStatusDto(
+            newStatus1.eventId,
+            kanaler = listOf("SMS"),
+            status = "newestStatus",
+            melding = "newestMelding"
+        )
+
+        val oppgave = giveMeOppgaveWithEventIdAndAppnavn(newStatus1.eventId, newStatus1.bestillerAppnavn)
+
+        val existingStatus = createDoknotifikasjonStatusDto(
+            eventId = newStatus1.eventId,
+            antallOppdateringer = 3,
+            kanaler = listOf("EPOST")
+        )
+
+        coEvery {
+            oppgaveRepository.getOppgaveWithEksternVarslingForEventIds(any())
+        } returns listOf(oppgave)
+
+        val persistResult = createPersistActionResult(
+            successful = listOf(newStatus2),
+            unchanged = emptyList()
+        )
+
+        val persistedSlot = slot<List<DoknotifikasjonStatusDto>>()
+
+        coEvery {
+            doknotStatusRepository.getStatusesForOppgave(listOf(newStatus1.eventId))
+        } returns listOf(existingStatus)
+
+        coEvery {
+            doknotStatusRepository.updateStatusesForOppgave(capture(persistedSlot))
+        } returns persistResult
+
+        runBlocking {
+            statusUpdater.updateStatusForOppgave(listOf(newStatus1, newStatus2))
+        }
+
+        val persistedStatus = persistedSlot.captured[0]
+
+        persistedStatus.status shouldBe newStatus2.status
+        persistedStatus.melding shouldBe newStatus2.melding
+        persistedStatus.kanaler.size shouldBe 2
+        persistedStatus.kanaler shouldContainAll listOf("SMS", "EPOST")
+        persistedStatus.antallOppdateringer shouldBe 5
+    }
+
+    @Test
     fun `should attempt to match statuses with existing innboks events and update`() {
-        val innboks1 = giveMeInnboksWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
-        val innboks2 = giveMeInnboksWithEventIdAndAppnavn(status2.getBestillingsId(), status2.getBestillerId())
+        val innboks1 = giveMeInnboksWithEventIdAndAppnavn(status1.eventId, status1.bestillerAppnavn)
+        val innboks2 = giveMeInnboksWithEventIdAndAppnavn(status2.eventId, status2.bestillerAppnavn)
 
         coEvery {
             innboksRepository.getInnboksWithEksternVarslingForEventIds(any())
@@ -182,12 +294,15 @@ internal class DoknotifikasjonStatusUpdaterTest {
             doknotStatusRepository.updateStatusesForInnboks(listOf(status1, status2))
         } returns persistResult
 
+        coEvery {
+            doknotStatusRepository.getStatusesForInnboks(any())
+        } returns emptyList()
+
         val result = runBlocking {
             statusUpdater.updateStatusForInnboks(statuses)
         }
 
         result.updatedStatuses shouldContain status1
-        result.unchangedStatuses shouldContain status2
         result.unmatchedStatuses shouldContain status3
 
         coVerify(exactly = 1) { innboksRepository.getInnboksWithEksternVarslingForEventIds(any()) }
@@ -197,8 +312,8 @@ internal class DoknotifikasjonStatusUpdaterTest {
 
     @Test
     fun `should not consider status to match innboks if appnavn differs from bestillingsId`() {
-        val innboks1 = giveMeInnboksWithEventIdAndAppnavn(status1.getBestillingsId(), status1.getBestillerId())
-        val innboks2 = giveMeInnboksWithEventIdAndAppnavn(status2.getBestillingsId(), "other")
+        val innboks1 = giveMeInnboksWithEventIdAndAppnavn(status1.eventId, status1.bestillerAppnavn)
+        val innboks2 = giveMeInnboksWithEventIdAndAppnavn(status2.eventId, "other")
 
         coEvery {
             innboksRepository.getInnboksWithEksternVarslingForEventIds(any())
@@ -213,17 +328,72 @@ internal class DoknotifikasjonStatusUpdaterTest {
             doknotStatusRepository.updateStatusesForInnboks(listOf(status1))
         } returns persistResult
 
+        coEvery {
+            doknotStatusRepository.getStatusesForInnboks(any())
+        } returns emptyList()
+
         val result = runBlocking {
             statusUpdater.updateStatusForInnboks(statuses)
         }
 
         result.updatedStatuses shouldContain status1
-        result.unchangedStatuses.isEmpty() shouldBe true
         result.unmatchedStatuses shouldContainAll listOf(status2, status3)
 
         coVerify(exactly = 1) { innboksRepository.getInnboksWithEksternVarslingForEventIds(any()) }
         coVerify(exactly = 1) { doknotStatusRepository.updateStatusesForInnboks(any()) }
         coVerify(exactly = 0) { beskjedRepository.getBeskjedWithEksternVarslingForEventIds(any()) }
+    }
+
+    @Test
+    fun `should update if status already exists for innboks`() {
+
+        val newStatus1 = createDoknotifikasjonStatusDto("innboks",kanaler = listOf("SMS"))
+
+        val newStatus2 = createDoknotifikasjonStatusDto(
+            newStatus1.eventId,
+            kanaler = listOf("SMS"),
+            status = "newestStatus",
+            melding = "newestMelding"
+        )
+
+        val innboks = giveMeInnboksWithEventIdAndAppnavn(newStatus1.eventId, newStatus1.bestillerAppnavn)
+
+        val existingStatus = createDoknotifikasjonStatusDto(
+            eventId = newStatus1.eventId,
+            antallOppdateringer = 3,
+            kanaler = listOf("EPOST")
+        )
+
+        coEvery {
+            innboksRepository.getInnboksWithEksternVarslingForEventIds(any())
+        } returns listOf(innboks)
+
+        val persistResult = createPersistActionResult(
+            successful = listOf(newStatus2),
+            unchanged = emptyList()
+        )
+
+        val persistedSlot = slot<List<DoknotifikasjonStatusDto>>()
+
+        coEvery {
+            doknotStatusRepository.getStatusesForInnboks(listOf(newStatus1.eventId))
+        } returns listOf(existingStatus)
+
+        coEvery {
+            doknotStatusRepository.updateStatusesForInnboks(capture(persistedSlot))
+        } returns persistResult
+
+        runBlocking {
+            statusUpdater.updateStatusForInnboks(listOf(newStatus1, newStatus2))
+        }
+
+        val persistedStatus = persistedSlot.captured[0]
+
+        persistedStatus.status shouldBe newStatus2.status
+        persistedStatus.melding shouldBe newStatus2.melding
+        persistedStatus.kanaler.size shouldBe 2
+        persistedStatus.kanaler shouldContainAll listOf("SMS", "EPOST")
+        persistedStatus.antallOppdateringer shouldBe 5
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotofikasjonStatusTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotofikasjonStatusTransformerTest.kt
@@ -1,0 +1,40 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+
+internal class DoknotofikasjonStatusTransformerTest {
+    @Test
+    fun `should transform to internal dto`() {
+        val external = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(
+            bestillingsId = "testId",
+            bestiller = "bestiller",
+            status = "status",
+            melding = "some melding",
+            distribusjonsId = 123
+        )
+
+        val internal = DoknotofikasjonStatusTransformer.toInternal(external)
+
+        external.getBestillerId() shouldBe internal.bestillerAppnavn
+        external.getBestillingsId() shouldBe internal.eventId
+        external.getStatus() shouldBe internal.status
+        external.getMelding() shouldBe internal.melding
+        external.getDistribusjonId() shouldBe internal.distribusjonsId
+        internal.kanaler.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `should parse kanal where applicable`() {
+        val external = DoknotifikasjonStatusObjectMother.createDoknotifikasjonStatus(
+            bestillingsId = "test",
+            melding = "notifikasjon sendt via mail"
+        )
+
+        val internal = DoknotofikasjonStatusTransformer.toInternal(external)
+
+        internal.kanaler shouldContain "MAIL"
+    }
+}


### PR DESCRIPTION
Legger til naiv parsing av brukt kanal for ekstern varsling. 

Endrer og flytter også litt på logikken rundt oppdatering av status. "uendret" forsvinner som konsept, og alle oppdateringer vil øke feltet "antall_oppdateringer", selv når alle andre felt forble det samme. 