### PR TITLE
Matcher kun på eventId ved behandling av done.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/Brukernotifikasjon.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/Brukernotifikasjon.kt
@@ -12,7 +12,6 @@ data class Brukernotifikasjon(
 
     fun isRepresentsSameEventAs(doneEvent: Done): Boolean {
         if (eventId != doneEvent.eventId) return false
-        if (fodselsnummer != doneEvent.fodselsnummer) return false
 
         return true
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/entity/BrukernotifikasjonTest.kt
@@ -16,9 +16,17 @@ class BrukernotifikasjonTest{
     }
 
     @Test
-    internal fun `skal ikke match med ikke-tilhorende done-eventer`() {
+    internal fun `skal matche med eventer selv om fodselsnummer er forskjellig`() {
         val beskjed = BrukernotifikasjonObjectMother.giveMeBeskjed()
         val ikkeMatchendeDoneEvent = DoneObjectMother.giveMeDone(beskjed.eventId, beskjed.systembruker, "7654")
+
+        beskjed.isRepresentsSameEventAs(ikkeMatchendeDoneEvent) shouldBe true
+    }
+
+    @Test
+    internal fun `skal ikke matche med andre eventIder`() {
+        val beskjed = BrukernotifikasjonObjectMother.giveMeBeskjed()
+        val ikkeMatchendeDoneEvent = DoneObjectMother.giveMeDone(beskjed.eventId + "1", beskjed.systembruker, beskjed.fodselsnummer)
 
         beskjed.isRepresentsSameEventAs(ikkeMatchendeDoneEvent) shouldBe false
     }


### PR DESCRIPTION
Dette forhindrer tilfeller der done ikke matches fordi bruker har flere ID-er.