### PR TITLE
Legger til historikk for ekstern varsling og info om renotifikasjon.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/queryUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/database/queryUtil.kt
@@ -61,7 +61,7 @@ fun Connection.executePersistQuery(sql: String, paramInit: PreparedStatement.() 
             }
         }
 
-fun ResultSet.getListFromSeparatedString(columnLabel: String, separator: String): List<String> {
+fun ResultSet.getListFromString(columnLabel: String, separator: String = ","): List<String> {
     val stringValue = getString(columnLabel)
     return if(stringValue.isNullOrEmpty()) {
         emptyList()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusDto.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusDto.kt
@@ -1,11 +1,13 @@
 package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
 
+import java.time.LocalDateTime
+
 data class DoknotifikasjonStatusDto(
     val eventId: String,
     val bestillerAppnavn: String,
     val status: String,
     val melding: String,
     val distribusjonsId: Long?,
-    val kanaler: List<String>,
-    val antallOppdateringer: Int = 1
+    val kanal: String?,
+    val tidspunkt: LocalDateTime
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusEnum.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusEnum.kt
@@ -1,5 +1,17 @@
 package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
 
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.EksternStatus.*
+
 enum class DoknotifikasjonStatusEnum {
     FEILET, INFO, OVERSENDT, FERDIGSTILT;
+
+    companion object {
+        fun fromInternal(status: EksternStatus) = when(status) {
+            Feilet -> FEILET
+            Info -> INFO
+            Bestilt -> OVERSENDT
+            Sendt -> FERDIGSTILT
+            Ferdigstilt -> FERDIGSTILT
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternStatusOppdatering.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternStatusOppdatering.kt
@@ -8,10 +8,8 @@ data class EksternStatusOppdatering(
     val varselType: VarselType,
     val namespace: String,
     val appnavn: String,
-    val kanal: String?
+    val kanal: String?,
+    val renotifikasjon: Boolean?
 )
-enum class EksternStatus {
-    Feilet, Info, Bestilt, Sendt, Ferdigstilt;
 
-    val lowercaseName = name.lowercase()
-}
+

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingOppdatertProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingOppdatertProducer.kt
@@ -26,6 +26,7 @@ class EksternVarslingOppdatertProducer(private val kafkaProducer: Producer<Strin
 
         if (oppdatering.status == EksternStatus.Sendt) {
             objectNode.put("kanal", oppdatering.kanal)
+            objectNode.put("renotifikasjon", oppdatering.renotifikasjon)
         }
 
         val producerRecord = ProducerRecord(topicName, oppdatering.eventId, objectNode.toString())

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingStatus.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingStatus.kt
@@ -1,0 +1,32 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import com.fasterxml.jackson.annotation.JsonValue
+import java.time.LocalDateTime
+
+data class EksternVarslingStatus(
+    val eventId: String,
+    val eksternVarslingSendt: Boolean,
+    val renotifikasjonSendt: Boolean,
+    val kanaler: List<String>,
+    val sistMottattStatus: String,
+    val historikk: List<EksternVarslingHistorikkEntry>,
+    val sistOppdatert: LocalDateTime
+)
+
+data class EksternVarslingHistorikkEntry(
+    val melding: String,
+    val status: EksternStatus,
+    val distribusjonsId: Long?,
+    val kanal: String?,
+    val renotifikasjon: Boolean?,
+    val tidspunkt: LocalDateTime
+)
+
+enum class EksternStatus {
+    Feilet, Info, Bestilt, Sendt, Ferdigstilt;
+
+    val lowercaseName = name.lowercase()
+
+    @JsonValue
+    fun toJson() = lowercaseName
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingStatusRepository.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingStatusRepository.kt
@@ -5,15 +5,15 @@ import no.nav.personbruker.dittnav.eventaggregator.varsel.VarselType
 
 class EksternVarslingStatusRepository(private val database: Database) {
 
-    suspend fun getStatusIfExists(eventId: String, varselType: VarselType): DoknotifikasjonStatusDto? {
+    suspend fun getStatusIfExists(eventId: String, varselType: VarselType): EksternVarslingStatus? {
         return database.queryWithExceptionTranslation {
-            getStatusIfExists(eventId, varselType)
+            getEksternVarslingStatusIfExists(eventId, varselType)
         }
     }
 
-    suspend fun updateStatus(dokStatus: DoknotifikasjonStatusDto, varselType: VarselType) {
+    suspend fun updateStatus(dokStatus: EksternVarslingStatus, varselType: VarselType) {
         database.queryWithExceptionTranslation {
-            upsertDoknotifikasjonStatus(dokStatus, varselType)
+            upsertEksternVarslingStatus(dokStatus, varselType)
         }
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingStatusUpdater.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingStatusUpdater.kt
@@ -1,9 +1,12 @@
 package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
 
+import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeHelper.nowAtUtc
 import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.DoknotifikasjonStatusEnum.*
 import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.EksternStatus.*
 import no.nav.personbruker.dittnav.eventaggregator.varsel.VarselHeader
 import no.nav.personbruker.dittnav.eventaggregator.varsel.VarselRepository
+import java.time.Duration
+import java.time.temporal.ChronoUnit
 
 class EksternVarslingStatusUpdater(
     private val eksternVarslingStatusRepository: EksternVarslingStatusRepository,
@@ -11,49 +14,118 @@ class EksternVarslingStatusUpdater(
     private val eksternVarslingOppdatertProducer: EksternVarslingOppdatertProducer
 ) {
 
-    suspend fun insertOrUpdateStatus(newStatus: DoknotifikasjonStatusDto) {
-        val varsel = varselRepository.getVarsel(newStatus.eventId)
+    suspend fun insertOrUpdateStatus(statusEvent: DoknotifikasjonStatusDto) {
+        val varsel = varselRepository.getVarsel(statusEvent.eventId)
 
         if (varsel == null) {
             return
         }
 
-        val existingStatus = eksternVarslingStatusRepository.getStatusIfExists(newStatus.eventId, varsel.type)
+        val currentStatus = eksternVarslingStatusRepository.getStatusIfExists(statusEvent.eventId, varsel.type)
 
-        val statusToPersist = existingStatus?.let {
-            mergeStatuses(it, newStatus)
-        } ?: newStatus
-
-        eksternVarslingStatusRepository.updateStatus(statusToPersist, varsel.type)
-
-        eksternVarslingOppdatertProducer.eksternStatusOppdatert(mergeOppdatering(varsel, newStatus))
+        if (currentStatus == null) {
+            insertNewStatus(statusEvent, varsel)
+        } else if (hasNotReceivedSameStatus(currentStatus, statusEvent)) {
+            updateExistingStatus(statusEvent, currentStatus, varsel)
+        }
     }
 
-    private fun mergeStatuses(oldStatus: DoknotifikasjonStatusDto, newStatus: DoknotifikasjonStatusDto): DoknotifikasjonStatusDto {
-        val kanaler = (oldStatus.kanaler + newStatus.kanaler).distinct()
-
-        return newStatus.copy(
-            kanaler = kanaler,
-            antallOppdateringer = oldStatus.antallOppdateringer + 1
+    private suspend fun insertNewStatus(statusEvent: DoknotifikasjonStatusDto, varsel: VarselHeader) {
+        val newEntry = EksternVarslingHistorikkEntry(
+            melding = statusEvent.melding,
+            status = determineInternalStatus(statusEvent),
+            distribusjonsId = statusEvent.distribusjonsId,
+            kanal = statusEvent.kanal,
+            renotifikasjon = false,
+            tidspunkt = statusEvent.tidspunkt
         )
+
+        val newStatus = EksternVarslingStatus(
+            eventId = statusEvent.eventId,
+            eksternVarslingSendt = newEntry.status == Sendt,
+            renotifikasjonSendt = false,
+            kanaler = listOfNotNull(newEntry.kanal),
+            sistMottattStatus = statusEvent.status,
+            historikk = listOf(newEntry),
+            sistOppdatert = nowAtUtc()
+        )
+
+        eksternVarslingStatusRepository.updateStatus(newStatus, varsel.type)
+
+        eksternVarslingOppdatertProducer.eksternStatusOppdatert(buildOppdatering(newEntry, varsel))
     }
 
-    private fun mergeOppdatering(varsel: VarselHeader, statusDto: DoknotifikasjonStatusDto) = EksternStatusOppdatering(
-        status = determineStatus(statusDto),
-        kanal = statusDto.kanaler.firstOrNull(),
+    private suspend fun updateExistingStatus(statusEvent: DoknotifikasjonStatusDto, currentStatus: EksternVarslingStatus, varsel: VarselHeader) {
+        val newEntry = EksternVarslingHistorikkEntry(
+            melding = statusEvent.melding,
+            status = determineInternalStatus(statusEvent),
+            distribusjonsId = statusEvent.distribusjonsId,
+            kanal = statusEvent.kanal,
+            renotifikasjon = determineIfRenotifikasjon(currentStatus, statusEvent),
+            tidspunkt = statusEvent.tidspunkt
+        )
+
+        val updatedStatus = EksternVarslingStatus(
+            eventId = currentStatus.eventId,
+            eksternVarslingSendt = currentStatus.eksternVarslingSendt || newEntry.status == Sendt,
+            renotifikasjonSendt = if (newEntry.renotifikasjon == true) true else currentStatus.renotifikasjonSendt,
+            kanaler = (currentStatus.kanaler + newEntry.kanal).filterNotNull().distinct(),
+            sistMottattStatus = statusEvent.status,
+            historikk = currentStatus.historikk + newEntry,
+            sistOppdatert = nowAtUtc()
+        )
+
+        eksternVarslingStatusRepository.updateStatus(updatedStatus, varsel.type)
+
+        eksternVarslingOppdatertProducer.eksternStatusOppdatert(buildOppdatering(newEntry, varsel))
+    }
+
+    private fun determineIfRenotifikasjon(currentStatus: EksternVarslingStatus, statusEvent: DoknotifikasjonStatusDto): Boolean {
+        return when {
+            determineInternalStatus(statusEvent) != Sendt -> false
+            isFirstAttempt(currentStatus) -> false
+            intervalSinceFirstAttempt(currentStatus, statusEvent) > Duration.ofHours(23) -> true
+            else -> false
+        }
+    }
+
+    private fun isFirstAttempt(currentStatus: EksternVarslingStatus): Boolean {
+        return currentStatus.historikk.none { it.status == Sendt || it.status == Feilet }
+    }
+
+    private fun hasNotReceivedSameStatus(currentStatus: EksternVarslingStatus, statusEvent: DoknotifikasjonStatusDto): Boolean {
+        return currentStatus.historikk
+            .filter { it.status == determineInternalStatus(statusEvent) }
+            .filter { it.distribusjonsId == statusEvent.distribusjonsId }
+            .filter { it.tidspunkt.truncatedTo(ChronoUnit.MILLIS) == statusEvent.tidspunkt.truncatedTo(ChronoUnit.MILLIS) }
+            .none()
+    }
+
+    private fun intervalSinceFirstAttempt(currentStatus: EksternVarslingStatus, statusEvent: DoknotifikasjonStatusDto): Duration {
+        val previous = currentStatus.historikk
+            .filter { it.status == Sendt || it.status == Feilet }
+            .minOf { it.tidspunkt }
+
+        return Duration.between(previous, statusEvent.tidspunkt)
+    }
+
+    private fun buildOppdatering(newEntry: EksternVarslingHistorikkEntry, varsel: VarselHeader) = EksternStatusOppdatering(
+        status = newEntry.status,
+        kanal = newEntry.kanal,
         varselType = varsel.type,
         eventId = varsel.eventId,
         namespace = varsel.namespace,
-        appnavn = varsel.appnavn
+        appnavn = varsel.appnavn,
+        renotifikasjon = newEntry.renotifikasjon
     )
 
-    private fun determineStatus(statusDto: DoknotifikasjonStatusDto): EksternStatus {
-        return when(statusDto.status) {
-            FERDIGSTILT.name -> if (statusDto.kanaler.isNotEmpty()) Sendt else Ferdigstilt
+    private fun determineInternalStatus(statusEvent: DoknotifikasjonStatusDto): EksternStatus {
+        return when(statusEvent.status) {
+            FERDIGSTILT.name -> if (statusEvent.kanal.isNullOrBlank()) Ferdigstilt else Sendt
             INFO.name -> Info
             FEILET.name -> Feilet
             OVERSENDT.name -> Bestilt
-            else -> throw IllegalArgumentException("Kjente ikke igjen doknotifikasjon status ${statusDto.status}.")
+            else -> throw IllegalArgumentException("Kjente ikke igjen doknotifikasjon status ${statusEvent.status}.")
         }
     }
 }

--- a/src/main/resources/db/migration/V1.1.33__Endre_doknotifikasjon_status.sql
+++ b/src/main/resources/db/migration/V1.1.33__Endre_doknotifikasjon_status.sql
@@ -1,0 +1,37 @@
+alter table doknotifikasjon_status_beskjed drop column melding;
+alter table doknotifikasjon_status_beskjed drop column distribusjonsid;
+alter table doknotifikasjon_status_beskjed drop column antall_oppdateringer;
+alter table doknotifikasjon_status_beskjed rename column tidspunkt to sistOppdatert;
+alter table doknotifikasjon_status_beskjed rename column status to sistMottattStatus;
+
+alter table doknotifikasjon_status_oppgave drop column melding;
+alter table doknotifikasjon_status_oppgave drop column distribusjonsid;
+alter table doknotifikasjon_status_oppgave drop column antall_oppdateringer;
+alter table doknotifikasjon_status_oppgave rename column tidspunkt to sistOppdatert;
+alter table doknotifikasjon_status_oppgave rename column status to sistMottattStatus;
+
+alter table doknotifikasjon_status_innboks drop column melding;
+alter table doknotifikasjon_status_innboks drop column distribusjonsid;
+alter table doknotifikasjon_status_innboks drop column antall_oppdateringer;
+alter table doknotifikasjon_status_innboks rename column tidspunkt to sistOppdatert;
+alter table doknotifikasjon_status_innboks rename column status to sistMottattStatus;
+
+alter table doknotifikasjon_status_beskjed add column eksternVarslingSendt bool;
+alter table doknotifikasjon_status_oppgave add column eksternVarslingSendt bool;
+alter table doknotifikasjon_status_innboks add column eksternVarslingSendt bool;
+
+alter table doknotifikasjon_status_beskjed add column renotifikasjonSendt bool;
+alter table doknotifikasjon_status_oppgave add column renotifikasjonSendt bool;
+alter table doknotifikasjon_status_innboks add column renotifikasjonSendt bool;
+
+alter table doknotifikasjon_status_beskjed add column historikk jsonb;
+alter table doknotifikasjon_status_oppgave add column historikk jsonb;
+alter table doknotifikasjon_status_innboks add column historikk jsonb;
+
+alter table doknotifikasjon_status_beskjed rename to ekstern_varsling_status_beskjed;
+alter table doknotifikasjon_status_oppgave rename to ekstern_varsling_status_oppgave;
+alter table doknotifikasjon_status_innboks rename to ekstern_varsling_status_innboks;
+
+create view doknotifikasjon_status_beskjed as select *, sistMottattStatus as status from ekstern_varsling_status_beskjed;
+create view doknotifikasjon_status_oppgave as select *, sistMottattStatus as status from ekstern_varsling_status_oppgave;
+create view doknotifikasjon_status_innboks as select *, sistMottattStatus as status from ekstern_varsling_status_innboks;

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedQueriesTest.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.eventaggregator.beskjed
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowTruncatedToMillis
+import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowAtUtcTruncated
 import no.nav.personbruker.dittnav.eventaggregator.common.database.LocalPostgresDatabase
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -34,7 +34,7 @@ class BeskjedQueriesTest {
     @Test
     fun `Finner utgåtte beskjeder`() {
         runBlocking {
-            val expiredBeskjed = BeskjedTestData.beskjed(synligFremTil = nowTruncatedToMillis().minusDays(1))
+            val expiredBeskjed = BeskjedTestData.beskjed(synligFremTil = nowAtUtcTruncated().minusDays(1))
             database.dbQuery { createBeskjed(expiredBeskjed) }
 
             val numberUpdated = database.dbQuery {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTestData.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/BeskjedTestData.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
-import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowTruncatedToMillis
+import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowAtUtcTruncated
 import java.time.LocalDateTime
 
 object BeskjedTestData {
@@ -9,15 +9,15 @@ object BeskjedTestData {
         systembruker: String = "systembruker",
         namespace: String = "namespace",
         appnavn: String = "appnavn",
-        eventTidspunkt: LocalDateTime = nowTruncatedToMillis(),
-        forstBehandlet: LocalDateTime = nowTruncatedToMillis(),
-        synligFremTil: LocalDateTime = nowTruncatedToMillis().plusDays(1),
+        eventTidspunkt: LocalDateTime = nowAtUtcTruncated(),
+        forstBehandlet: LocalDateTime = nowAtUtcTruncated(),
+        synligFremTil: LocalDateTime = nowAtUtcTruncated().plusDays(1),
         fodselsnummer: String = "123",
         eventId: String = "12345",
         grupperingsId: String = "grupperingsId",
         tekst: String = "tekst",
         link: String = "http://link",
-        sistOppdatert: LocalDateTime = nowTruncatedToMillis(),
+        sistOppdatert: LocalDateTime = nowAtUtcTruncated(),
         sikkerhetsnivaa: Int = 4,
         aktiv: Boolean = true,
         eksternVarsling: Boolean = false,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/testBeskjedQueries.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/beskjed/testBeskjedQueries.kt
@@ -1,12 +1,11 @@
 package no.nav.personbruker.dittnav.eventaggregator.beskjed
 
-import no.nav.personbruker.dittnav.eventaggregator.common.database.getListFromSeparatedString
+import no.nav.personbruker.dittnav.eventaggregator.common.database.getListFromString
 import no.nav.personbruker.dittnav.eventaggregator.common.database.getNullableLocalDateTime
 import no.nav.personbruker.dittnav.eventaggregator.common.database.getUtcDateTime
 import no.nav.personbruker.dittnav.eventaggregator.common.database.list
 import no.nav.personbruker.dittnav.eventaggregator.common.database.singleResult
 import no.nav.personbruker.dittnav.eventaggregator.common.getFristUtløpt
-import no.nav.personbruker.dittnav.eventaggregator.varsel.VarselType
 import java.sql.Connection
 import java.sql.ResultSet
 
@@ -57,6 +56,6 @@ fun ResultSet.toBeskjed() = Beskjed(
     synligFremTil = getNullableLocalDateTime("synligFremTil"),
     aktiv = getBoolean("aktiv"),
     eksternVarsling = getBoolean("eksternVarsling"),
-    prefererteKanaler = getListFromSeparatedString("prefererteKanaler", ","),
+    prefererteKanaler = getListFromString("prefererteKanaler", ","),
     fristUtløpt = getFristUtløpt()
 )

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/LocalDateTimeTestHelper.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/common/LocalDateTimeTestHelper.kt
@@ -4,6 +4,6 @@ import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
 object LocalDateTimeTestHelper {
-    fun nowTruncatedToMillis(): LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)
+    fun nowAtUtcTruncated(): LocalDateTime = LocalDateTimeHelper.nowAtUtc().truncatedTo(ChronoUnit.MILLIS)
 }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusDtoTestData.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/DoknotifikasjonStatusDtoTestData.kt
@@ -1,5 +1,8 @@
 package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
 
+import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowAtUtcTruncated
+import java.time.LocalDateTime
+
 object DoknotifikasjonStatusDtoTestData {
 
     fun createDoknotifikasjonStatusDto(
@@ -8,8 +11,8 @@ object DoknotifikasjonStatusDtoTestData {
         status: String =  "INFO",
         melding: String = "dummyMelding",
         distribusjonsId: Long = 1L,
-        kanaler: List<String> = emptyList(),
-        antallOppdateringer: Int =  1
+        kanal: String? = null,
+        tidspunkt: LocalDateTime = nowAtUtcTruncated()
     ): DoknotifikasjonStatusDto {
         return DoknotifikasjonStatusDto(
             eventId = eventId,
@@ -17,8 +20,8 @@ object DoknotifikasjonStatusDtoTestData {
             status = status,
             melding = melding,
             distribusjonsId = distribusjonsId,
-            kanaler = kanaler,
-            antallOppdateringer = antallOppdateringer,
+            kanal = kanal,
+            tidspunkt = tidspunkt
         )
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingStatusTestData.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/EksternVarslingStatusTestData.kt
@@ -1,0 +1,36 @@
+package no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon
+
+import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowAtUtcTruncated
+import no.nav.personbruker.dittnav.eventaggregator.doknotifikasjon.DoknotifikasjonStatusEnum.Companion.fromInternal
+import java.time.LocalDateTime
+
+object EksternVarslingStatusTestData {
+
+    fun createEksternvarslingStatus(
+        eventId: String,
+        status: EksternStatus,
+        kanal: String,
+        renotifikasjon: Boolean = false,
+        melding: String = "dummyMelding",
+        distribusjonsId: Long = 1L,
+        sistOppdatert: LocalDateTime =  nowAtUtcTruncated()
+    ) = EksternVarslingStatus (
+        eventId = eventId,
+        kanaler = listOf(kanal),
+        sistMottattStatus = fromInternal(status).name,
+        eksternVarslingSendt = status == EksternStatus.Sendt,
+        renotifikasjonSendt = renotifikasjon,
+        historikk = listOf(
+            EksternVarslingHistorikkEntry(
+                melding = melding,
+                status = status,
+                distribusjonsId = distribusjonsId,
+                kanal = kanal,
+                renotifikasjon = renotifikasjon,
+                tidspunkt = sistOppdatert
+            )
+        ),
+        sistOppdatert = sistOppdatert
+    )
+}
+

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/testDoknotifikasjonStatusQueries.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/doknotifikasjon/testDoknotifikasjonStatusQueries.kt
@@ -6,53 +6,47 @@ import java.sql.Connection
 import java.sql.ResultSet
 
 fun Connection.deleteAllDoknotifikasjonStatusBeskjed() {
-    prepareStatement("""DELETE FROM doknotifikasjon_status_beskjed""")
+    prepareStatement("""DELETE FROM ekstern_varsling_status_beskjed""")
         .use {it.execute()}
 }
 
 fun Connection.deleteAllDoknotifikasjonStatusOppgave() {
-    prepareStatement("""DELETE FROM doknotifikasjon_status_oppgave""")
+    prepareStatement("""DELETE FROM ekstern_varsling_status_oppgave""")
         .use {it.execute()}
 }
 
 
 fun Connection.deleteAllDoknotifikasjonStatusInnboks() {
-    prepareStatement("""DELETE FROM doknotifikasjon_status_innboks""")
+    prepareStatement("""DELETE FROM ekstern_varsling_status_innboks""")
         .use {it.execute()}
 }
 
-fun Connection.getAllDoknotifikasjonStatusBeskjed(): List<DoknotStatusDTO> {
-    return prepareStatement("""SELECT * FROM doknotifikasjon_status_beskjed""")
+fun Connection.countEksternVarslingStatusBeskjed(): Int {
+    return prepareStatement("""SELECT count(*) as antall FROM ekstern_varsling_status_beskjed""")
         .use {
-            it.executeQuery().list {
-                toDoknotStatusDTO()
+            it.executeQuery().run {
+                next()
+                getInt("antall")
             }
         }
 }
 
-fun Connection.getAllDoknotifikasjonStatusOppgave(): List<DoknotStatusDTO> {
-    return prepareStatement("""SELECT * FROM doknotifikasjon_status_oppgave""")
+fun Connection.countEksternVarslingStatusOppgave(): Int {
+    return prepareStatement("""SELECT count(*) as antall FROM ekstern_varsling_status_oppgave""")
         .use {
-            it.executeQuery().list {
-                toDoknotStatusDTO()
+            it.executeQuery().run {
+                next()
+                getInt("antall")
             }
         }
 }
 
-fun Connection.getAllDoknotifikasjonStatusInnboks(): List<DoknotStatusDTO> {
-    return prepareStatement("""SELECT * FROM doknotifikasjon_status_innboks""")
+fun Connection.countEksternVarslingStatusInnboks(): Int {
+    return prepareStatement("""SELECT count(*) as antall FROM ekstern_varsling_status_innboks""")
         .use {
-            it.executeQuery().list {
-                toDoknotStatusDTO()
+            it.executeQuery().run {
+                next()
+                getInt("antall")
             }
         }
 }
-
-private fun ResultSet.toDoknotStatusDTO() = DoknotStatusDTO(
-    eventId = getString("eventId"),
-    status = getString("status"),
-    melding = getString("melding"),
-    distribusjonsId = getLong("distribusjonsId"),
-    antallOppdateringer = getInt("antall_oppdateringer"),
-    tidspunkt = getUtcDateTime("tidspunkt"),
-)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTestData.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/done/DoneTestData.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.done
 
-import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowTruncatedToMillis
+import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowAtUtcTruncated
 import no.nav.personbruker.dittnav.eventaggregator.varsel.VarselHeader
 
 object DoneTestData {
@@ -10,11 +10,11 @@ object DoneTestData {
             namespace = namespace,
             appnavn = appnavn,
             eventId = eventId,
-            eventTidspunkt = nowTruncatedToMillis(),
-            forstBehandlet = nowTruncatedToMillis(),
+            eventTidspunkt = nowAtUtcTruncated(),
+            forstBehandlet = nowAtUtcTruncated(),
             fodselsnummer = fodselsnummer,
             grupperingsId = "100${eventId}",
-            sistBehandlet = nowTruncatedToMillis()
+            sistBehandlet = nowAtUtcTruncated()
         )
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/expired/PeriodicExpiredVarselProcessorTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/expired/PeriodicExpiredVarselProcessorTest.kt
@@ -14,10 +14,9 @@ import no.nav.personbruker.dittnav.eventaggregator.beskjed.createBeskjed
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.deleteAllBeskjed
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.getAllBeskjedByAktiv
 import no.nav.personbruker.dittnav.eventaggregator.beskjed.toBeskjed
-import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowTruncatedToMillis
+import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowAtUtcTruncated
 import no.nav.personbruker.dittnav.eventaggregator.common.database.LocalPostgresDatabase
 import no.nav.personbruker.dittnav.eventaggregator.common.database.list
-import no.nav.personbruker.dittnav.eventaggregator.done.VarselInaktivertKilde
 import no.nav.personbruker.dittnav.eventaggregator.done.VarselInaktivertKilde.Frist
 import no.nav.personbruker.dittnav.eventaggregator.done.VarselInaktivertProducer
 import no.nav.personbruker.dittnav.eventaggregator.metrics.DB_EVENTS_EXPIRED
@@ -50,8 +49,8 @@ internal class PeriodicExpiredVarselProcessorTest {
             ExpiredMetricsProbe(metricsReporter)
         )
 
-    private val pastDate = nowTruncatedToMillis().minusDays(7)
-    private val futureDate = nowTruncatedToMillis().plusDays(7)
+    private val pastDate = nowAtUtcTruncated().minusDays(7)
+    private val futureDate = nowAtUtcTruncated().plusDays(7)
 
     private val activeOppgave = OppgaveTestData.oppgave(
         synligFremTil = futureDate,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTestData.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/InnboksTestData.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
-import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowTruncatedToMillis
+import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowAtUtcTruncated
 import java.time.LocalDateTime
 
 object InnboksTestData {
@@ -9,14 +9,14 @@ object InnboksTestData {
         systembruker: String = "systembruker",
         namespace: String = "namespace",
         appnavn: String = "appnavn",
-        eventTidspunkt: LocalDateTime = nowTruncatedToMillis(),
-        forstBehandlet: LocalDateTime = nowTruncatedToMillis(),
+        eventTidspunkt: LocalDateTime = nowAtUtcTruncated(),
+        forstBehandlet: LocalDateTime = nowAtUtcTruncated(),
         fodselsnummer: String = "123",
         eventId: String = "76543",
         grupperingsId: String = "grupperingsId",
         tekst: String = "tekst",
         link: String = "http://link",
-        sistOppdatert: LocalDateTime = nowTruncatedToMillis(),
+        sistOppdatert: LocalDateTime = nowAtUtcTruncated(),
         sikkerhetsnivaa: Int = 4,
         aktiv: Boolean = true,
         eksternVarsling: Boolean = false,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/testInnboksQueries.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/innboks/testInnboksQueries.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.innboks
 
-import no.nav.personbruker.dittnav.eventaggregator.common.database.getListFromSeparatedString
+import no.nav.personbruker.dittnav.eventaggregator.common.database.getListFromString
 import no.nav.personbruker.dittnav.eventaggregator.common.database.getUtcDateTime
 import no.nav.personbruker.dittnav.eventaggregator.common.database.list
 import no.nav.personbruker.dittnav.eventaggregator.common.database.singleResult
@@ -43,6 +43,6 @@ fun ResultSet.toInnboks() = Innboks(
     sistOppdatert = getUtcDateTime("sistOppdatert"),
     aktiv = getBoolean("aktiv"),
     eksternVarsling = getBoolean("eksternVarsling"),
-    prefererteKanaler = getListFromSeparatedString("prefererteKanaler", ",")
+    prefererteKanaler = getListFromString("prefererteKanaler", ",")
 )
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveQueriesTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveQueriesTest.kt
@@ -25,7 +25,7 @@ class OppgaveQueriesTest {
     fun `Finner utgåtte oppgaver og setter inaktiv`() {
         runBlocking {
             val expiredOppgave = OppgaveTestData.oppgave(
-                synligFremTil = LocalDateTimeTestHelper.nowTruncatedToMillis().minusDays(1),
+                synligFremTil = LocalDateTimeTestHelper.nowAtUtcTruncated().minusDays(1),
                 fristUtløpt = null
             )
             database.dbQuery { createOppgave(expiredOppgave) }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTestData.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/OppgaveTestData.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
-import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowTruncatedToMillis
+import no.nav.personbruker.dittnav.eventaggregator.common.LocalDateTimeTestHelper.nowAtUtcTruncated
 import java.time.LocalDateTime
 
 object OppgaveTestData {
@@ -9,15 +9,15 @@ object OppgaveTestData {
         systembruker: String = "systembruker",
         namespace: String = "namespace",
         appnavn: String = "appnavn",
-        eventTidspunkt: LocalDateTime = nowTruncatedToMillis(),
-        forstBehandlet: LocalDateTime = nowTruncatedToMillis(),
-        synligFremTil: LocalDateTime = nowTruncatedToMillis().plusDays(1),
+        eventTidspunkt: LocalDateTime = nowAtUtcTruncated(),
+        forstBehandlet: LocalDateTime = nowAtUtcTruncated(),
+        synligFremTil: LocalDateTime = nowAtUtcTruncated().plusDays(1),
         fodselsnummer: String = "123",
         eventId: String = "o-123",
         grupperingsId: String = "Dok12345",
         tekst: String = "tekst",
         link: String = "https://link",
-        sistOppdatert: LocalDateTime = nowTruncatedToMillis(),
+        sistOppdatert: LocalDateTime = nowAtUtcTruncated(),
         sikkerhetsnivaa: Int = 4,
         aktiv: Boolean = true,
         eksternVarsling: Boolean = false,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/testOppgaveQueries.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventaggregator/oppgave/testOppgaveQueries.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.eventaggregator.oppgave
 
-import no.nav.personbruker.dittnav.eventaggregator.common.database.getListFromSeparatedString
+import no.nav.personbruker.dittnav.eventaggregator.common.database.getListFromString
 import no.nav.personbruker.dittnav.eventaggregator.common.database.getNullableLocalDateTime
 import no.nav.personbruker.dittnav.eventaggregator.common.database.getUtcDateTime
 import no.nav.personbruker.dittnav.eventaggregator.common.database.list
@@ -54,7 +54,7 @@ fun ResultSet.toOppgave() = Oppgave(
     sistOppdatert = getUtcDateTime("sistOppdatert"),
     aktiv = getBoolean("aktiv"),
     eksternVarsling = getBoolean("eksternVarsling"),
-    prefererteKanaler = getListFromSeparatedString("prefererteKanaler", ","),
+    prefererteKanaler = getListFromString("prefererteKanaler", ","),
     synligFremTil = getNullableLocalDateTime("synligFremTil"),
     fristUtløpt = getFristUtløpt()
 )


### PR DESCRIPTION
Endrer internt navn på doknotifikasjon status til ekstern varsling status, og bruker interne navn på statuser. Beholder historikk for tidligere statuser.

Bedømmer status dreier seg om renotifikasjon. Dette er basert på historikk som vi ikke har tatt vare på før nå. For tidligere varsler, og varsler sendt i en overgangsperiode, vil en ikke kunne se om det var renotifikasjon eller ikke.